### PR TITLE
Correct the case for "MultiPolygon"

### DIFF
--- a/gbfs-validator/schema/v2.1/station_information.json
+++ b/gbfs-validator/schema/v2.1/station_information.json
@@ -107,7 +107,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["Multipolygon"]
+                    "enum": ["MultiPolygon"]
                   },
                   "coordinates": {
                     "type": "array",

--- a/gbfs-validator/schema/v2.2/station_information.json
+++ b/gbfs-validator/schema/v2.2/station_information.json
@@ -107,7 +107,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["Multipolygon"]
+                    "enum": ["MultiPolygon"]
                   },
                   "coordinates": {
                     "type": "array",


### PR DESCRIPTION
I thought I was validating a feed with the validator, but I ended up validating the validator with the feed :)

There seems to be a case typo for virtual_areas expected enum : Multipolygon instead of MultiPolygon.

I give you the corresponding feed if you want to test it : https://data-sharing.tier-services.io/tier_grenoble/gbfs/2.2