### PR TITLE
vehicle_types.json is not required

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -23,7 +23,7 @@ The validator will check for the presence of those files depending on the option
 
 <img width="350" alt="tick boxes" src="https://user-images.githubusercontent.com/63653518/133173329-fab3967d-5e4c-459f-bd2f-ec3415b98d44.png">
 
-One additional conditionally required file has been added in  GBFS version 2.0.0:
+One additional conditionally required file has been added in GBFS version 2.1:
 vehicle_types.json
 The validator is currently considering this file as required, because the conditions are more complex and can’t be represented by the schema currently.
 

--- a/RULES.md
+++ b/RULES.md
@@ -25,7 +25,7 @@ The validator will check for the presence of those files depending on the option
 
 One additional conditionally required file has been added in GBFS version 2.1:
 vehicle_types.json
-The validator is currently considering this file as required, because the conditions are more complex and can’t be represented by the schema currently.
+The validator is currently considering this file as not required, because the conditions are more complex and can’t be represented by the schema currently.
 
 # Fields presence and types
 ## Required fields

--- a/gbfs-validator/schema/v2.1/index.js
+++ b/gbfs-validator/schema/v2.1/index.js
@@ -4,7 +4,7 @@ module.exports = {
     return [
       { file: 'gbfs_versions', required: false },
       { file: 'system_information', required: true },
-      { file: 'vehicle_types', required: true }, // @TODO Conditionally REQUIRED complexe
+      { file: 'vehicle_types', required: false }, // @TODO Conditionally REQUIRED complexe
       { file: 'station_information', required: options.docked },
       { file: 'station_status', required: options.docked },
       { file: 'free_bike_status', required: options.freefloating },

--- a/gbfs-validator/schema/v2.2/index.js
+++ b/gbfs-validator/schema/v2.2/index.js
@@ -4,7 +4,7 @@ module.exports = {
     return [
       { file: 'gbfs_versions', required: false },
       { file: 'system_information', required: true },
-      { file: 'vehicle_types', required: true }, // @TODO Conditionally REQUIRED complexe
+      { file: 'vehicle_types', required: false }, // @TODO Conditionally REQUIRED complexe
       { file: 'station_information', required: options.docked },
       { file: 'station_status', required: options.docked },
       { file: 'free_bike_status', required: options.freefloating },


### PR DESCRIPTION
Hi @isabelle-dr and contributors,

thanks for the good work!

I failed to raise this during yesterdays workshop as I only noticed after the slot was finished, but in my opinion, the validator should not declare potentially valid feeds as invalid. A feed rather should be considered _invalid_ only if it clearly is not, while stating it would be valid still does not mean it could not potentially be invalid (e.g. because `free_bike_status` refers to vehicle types that are not declared).

Full disclosure: Our implementation of `vehicle_types.json` is still in progress and even though the spec says we _should_ be publishing it, we are not required to do so and yet our feeds are considered invalid ;)