### PR TITLE
Start a validation when passing url query param

### DIFF
--- a/website/src/components/Validator.vue
+++ b/website/src/components/Validator.vue
@@ -143,6 +143,15 @@ export default {
       ]
     }
   },
+  mounted() {
+    // When specifying ?url=https://example.com/gbfs.json, start
+    // directly a validation
+    const url_query_param = new URL(location.href).searchParams.get('url')
+    if (url_query_param) {
+      this.url = url_query_param
+      this.valid()
+    }
+  },
   methods: {
     valid() {
       this.result = false


### PR DESCRIPTION
This PR adds the possibility to pass a `url` in the query param and start directly a validation.

This could be used to share links with partners, to share directly the result of a GBFS validation. URLs will look like: https://gbfs-validator.netlify.app/?url=https://transport.data.gouv.fr/gbfs/amiens/gbfs.json

I did not handle `options` for now, a `url` only is the most simple case.