### PR TITLE
Update URL when submitting form

### DIFF
--- a/website/src/components/Validator.vue
+++ b/website/src/components/Validator.vue
@@ -168,11 +168,17 @@ export default {
         .then(result => {
           this.isValidating = false
           this.result = result
+          this.updateURL()
         })
         .catch(result => {
           this.isValidating = false
           this.result = result
         })
+    },
+    updateURL() {
+      const searchParams = new URLSearchParams(window.location.search)
+      searchParams.set("url", this.url)
+      history.pushState(null, '', window.location.pathname + '?' + searchParams.toString())
     }
   }
 }


### PR DESCRIPTION
Follow up of #56. After submitting the form, update the current URL to include `?url=<url>` to make it easy to share the URL with others.

This is also a good opportunity to self document the feature added in #56