### PR TITLE
Add conditional requirement

### DIFF
--- a/functions/validator.js
+++ b/functions/validator.js
@@ -23,6 +23,7 @@ exports.handler = function(event, context, callback) {
       })
     })
     .catch(err => {
+      console.error(err)
       callback(null, {
         statusCode: 500,
         body: JSON.stringify(err.message)

--- a/gbfs-validator/__test__/fixtures/conditionnal_no_vehicle_type_id.js
+++ b/gbfs-validator/__test__/fixtures/conditionnal_no_vehicle_type_id.js
@@ -1,0 +1,82 @@
+const fastify = require('fastify')
+
+function build(opts = {}) {
+  const app = fastify(opts)
+
+  app.get('/gbfs.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        en: {
+          feeds: [
+            {
+              name: 'system_information',
+              url: `http://${request.hostname}/system_information.json`
+            },
+            {
+              name: 'station_information',
+              url: `http://${request.hostname}/station_information.json`
+            },
+            {
+              name: 'station_status',
+              url: `http://${request.hostname}/station_status.json`
+            },
+            {
+              name: 'free_bike_status',
+              url: `http://${request.hostname}/free_bike_status.json`
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  app.get('/system_information.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        system_id: 'shared_bike',
+        language: 'en',
+        name: 'Shared Bike USA',
+        timezone: 'UTC'
+      }
+    }
+  })
+
+  app.get('/free_bike_status.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        bikes: [
+          {
+            bike_id: 'bike1',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false
+          },
+          {
+            bike_id: 'bike2',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false,
+            vehicle_type_id: 'abc123'
+          }
+        ]
+      }
+    }
+  })
+
+  return app
+}
+
+module.exports = build

--- a/gbfs-validator/__test__/fixtures/conditionnal_vehicle_type_id.js
+++ b/gbfs-validator/__test__/fixtures/conditionnal_vehicle_type_id.js
@@ -1,0 +1,140 @@
+const fastify = require('fastify')
+
+function build(opts = {}) {
+  const app = fastify(opts)
+
+  app.get('/gbfs.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        en: {
+          feeds: [
+            {
+              name: 'system_information',
+              url: `http://${request.hostname}/system_information.json`
+            },
+            {
+              name: 'station_information',
+              url: `http://${request.hostname}/station_information.json`
+            },
+            {
+              name: 'station_status',
+              url: `http://${request.hostname}/station_status.json`
+            },
+            {
+              name: 'free_bike_status',
+              url: `http://${request.hostname}/free_bike_status.json`
+            },
+            {
+              name: 'vehicle_types',
+              url: `http://${request.hostname}/vehicle_types.json`
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  app.get('/system_information.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        system_id: 'shared_bike',
+        language: 'en',
+        name: 'Shared Bike USA',
+        timezone: 'UTC'
+      }
+    }
+  })
+
+  app.get('/vehicle_types.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        vehicle_types: [
+          {
+            vehicle_type_id: 'abc123',
+            form_factor: 'bicycle',
+            propulsion_type: 'human',
+            name: 'Example Basic Bike',
+            default_reserve_time: 30,
+            return_type: ['any_station', 'free_floating'],
+            vehicle_assets: {
+              icon_url: 'https://www.example.com/assets/icon_bicycle.svg',
+              icon_url_dark:
+                'https://www.example.com/assets/icon_bicycle_dark.svg',
+              icon_last_modified: '2021-06-15'
+            },
+            default_pricing_plan_id: 'bike_plan_1',
+            pricing_plan_ids: ['bike_plan_1', 'bike_plan_2', 'bike_plan_3']
+          },
+          {
+            vehicle_type_id: 'efg456',
+            form_factor: 'car',
+            propulsion_type: 'electric',
+            name: 'Example Electric Car',
+            default_reserve_time: 30,
+            return_type: ['any_station', 'free_floating'],
+            vehicle_assets: {
+              icon_url: 'https://www.example.com/assets/icon_car.svg',
+              icon_url_dark: 'https://www.example.com/assets/icon_car_dark.svg',
+              icon_last_modified: '2021-06-15'
+            },
+            default_pricing_plan_id: 'car_plan_1',
+            pricing_plan_ids: ['car_plan_1', 'car_plan_2', 'car_plan_3']
+          }
+        ]
+      }
+    }
+  })
+
+  app.get('/free_bike_status.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        bikes: [
+          {
+            bike_id: 'bike1',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false
+            // missing vehicle_type_id
+          },
+          {
+            bike_id: 'bike2',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false,
+            vehicle_type_id: 'abc123'
+          },
+          {
+            bike_id: 'car1',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false,
+            vehicle_type_id: 'efg456'
+            // missing current_range_meters
+          }
+        ]
+      }
+    }
+  })
+
+  return app
+}
+
+module.exports = build

--- a/gbfs-validator/__test__/fixtures/missing_vehicle_types.js
+++ b/gbfs-validator/__test__/fixtures/missing_vehicle_types.js
@@ -1,0 +1,74 @@
+const fastify = require('fastify')
+
+function build(opts = {}) {
+  const app = fastify(opts)
+
+  app.get('/gbfs.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        en: {
+          feeds: [
+            {
+              name: 'system_information',
+              url: `http://${request.hostname}/system_information.json`
+            },
+            {
+              name: 'station_information',
+              url: `http://${request.hostname}/station_information.json`
+            },
+            {
+              name: 'station_status',
+              url: `http://${request.hostname}/station_status.json`
+            },
+            {
+              name: 'free_bike_status',
+              url: `http://${request.hostname}/free_bike_status.json`
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  app.get('/system_information.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        system_id: 'shared_bike',
+        language: 'en',
+        name: 'Shared Bike USA',
+        timezone: 'UTC'
+      }
+    }
+  })
+
+  app.get('/free_bike_status.json', async function(request, reply) {
+    return {
+      last_updated: 1566224400,
+      ttl: 0,
+      version: '2.2',
+      data: {
+        bikes: [
+          {
+            bike_id: 'ghi789',
+            last_reported: 1609866109,
+            lat: 12.345678,
+            lon: 56.789012,
+            is_reserved: false,
+            is_disabled: false,
+            vehicle_type_id: 'abc123'
+          }
+        ]
+      }
+    }
+  })
+
+  return app
+}
+
+module.exports = build

--- a/gbfs-validator/__test__/gbfs.test.js
+++ b/gbfs-validator/__test__/gbfs.test.js
@@ -154,7 +154,7 @@ describe('checkAutodiscovery method', () => {
   })
 })
 
-describe('checkFile method', () => {
+describe('getFile method', () => {
   let gbfsFeedServer
 
   beforeAll(async () => {
@@ -169,7 +169,7 @@ describe('checkFile method', () => {
     return gbfsFeedServer.close()
   })
 
-  test('should check file using gbfs.json url', () => {
+  test('should get file using gbfs.json url', () => {
     const url = `http://${gbfsFeedServer.server.address().address}:${
       gbfsFeedServer.server.address().port
     }`
@@ -188,29 +188,24 @@ describe('checkFile method', () => {
       }
     }
 
-    return gbfs.checkFile('2.2', 'system_information', true).then(result => {
+    return gbfs.getFile('system_information', true).then(result => {
       expect(result).toMatchObject({
-        languages: expect.any(Array),
+        body: expect.any(Array),
         required: true,
-        exists: true,
-        file: 'system_information.json',
-        hasErrors: false
+        type: 'system_information'
       })
 
-      result.languages.forEach(l => {
+      result.body.forEach(l => {
         expect(l).toMatchObject({
-          errors: false,
           exists: true,
           lang: 'en',
-          url: `http://${gbfsFeedServer.server.address().address}:${
-            gbfsFeedServer.server.address().port
-          }/autodiscovery/system_information.json`
+          body: expect.any(Object)
         })
       })
     })
   })
 
-  test('should check file do not exist using gbfs.json url', () => {
+  test('should get file do not exist using gbfs.json url', () => {
     const url = `http://${gbfsFeedServer.server.address().address}:${
       gbfsFeedServer.server.address().port
     }`
@@ -229,18 +224,16 @@ describe('checkFile method', () => {
       }
     }
 
-    return gbfs.checkFile('2.2', 'do_not_exist', true).then(result => {
+    return gbfs.getFile('do_not_exist', true).then(result => {
       expect(result).toMatchObject({
-        languages: expect.any(Array),
+        body: expect.any(Array),
         required: true,
-        exists: false,
-        file: 'do_not_exist.json',
-        hasErrors: true
+        type: 'do_not_exist'
       })
 
-      result.languages.forEach(l => {
+      result.body.forEach(l => {
         expect(l).toMatchObject({
-          errors: false,
+          body: null,
           exists: false,
           lang: 'en',
           url: null
@@ -249,44 +242,158 @@ describe('checkFile method', () => {
     })
   })
 
-  test('should check file without autodiscovery', () => {
+  test('should get file without autodiscovery', () => {
     const url = `http://${gbfsFeedServer.server.address().address}:${
       gbfsFeedServer.server.address().port
     }`
     const gbfs = new GBFS(`${url}`)
 
-    return gbfs.checkFile('2.2', 'system_information', true).then(result => {
+    return gbfs.getFile('system_information', true).then(result => {
       expect(result).toMatchObject({
         required: true,
         exists: true,
-        file: 'system_information.json',
-        errors: [
-          {
-            instancePath: '/data',
-            keyword: 'required',
-            message: "must have required property 'language'",
-            params: {
-              missingProperty: 'language'
-            },
-            schemaPath: '#/properties/data/required'
-          }
-        ]
+        type: 'system_information',
+        body: expect.any(Object)
       })
     })
   })
 
-  test('should check file do not exist without autodiscovery', () => {
+  test('should get file do not exist without autodiscovery', () => {
     const url = `http://${gbfsFeedServer.server.address().address}:${
       gbfsFeedServer.server.address().port
     }`
     const gbfs = new GBFS(`${url}/gbfs.json`)
 
-    return gbfs.checkFile('2.2', 'do_not_exist', true).then(result => {
+    return gbfs.getFile('do_not_exist', true).then(result => {
       expect(result).toMatchObject({
+        body: null,
         required: true,
+        errors: expect.any(Error),
         exists: false,
-        file: 'do_not_exist.json',
-        errors: expect.any(Error)
+        type: 'do_not_exist'
+      })
+    })
+  })
+})
+
+describe('validationFile method', () => {
+  let gbfsFeedServer
+
+  beforeAll(async () => {
+    gbfsFeedServer = require('./fixtures/server')()
+
+    await gbfsFeedServer.listen()
+
+    return gbfsFeedServer
+  })
+
+  afterAll(() => {
+    return gbfsFeedServer.close()
+  })
+
+  test('should validate file with no lang', () => {
+    const gbfs = new GBFS(`http://localhost/gbfs.json`)
+
+    const result = gbfs.validationFile(
+      {
+        last_updated: 1566224400,
+        ttl: 0,
+        version: '2.2',
+        data: {
+          en: {
+            feeds: [
+              {
+                name: 'system_information',
+                url: `http://localhost/system_information.json`
+              },
+              {
+                name: 'station_information',
+                url: `http://localhost/station_information.json`
+              },
+              {
+                name: 'station_status',
+                url: `http://localhost/station_status.json`
+              },
+              {
+                name: 'free_bike_status',
+                url: `http://localhost/free_bike_status.json`
+              }
+            ]
+          }
+        }
+      },
+      '2.2',
+      'gbfs',
+      true,
+      {}
+    )
+
+    expect(result).toMatchObject({
+      required: true,
+      errors: false,
+      exists: true,
+      file: 'gbfs.json',
+      url: 'http://localhost/gbfs.json/gbfs.json'
+    })
+  })
+
+  test('should validate file with lang', () => {
+    const gbfs = new GBFS(`http://localhost/gbfs.json`)
+
+    const result = gbfs.validationFile(
+      [
+        {
+          body: {
+            last_updated: 1566224400,
+            ttl: 0,
+            version: '2.2',
+            data: {
+              en: {
+                feeds: [
+                  {
+                    name: 'system_information',
+                    url: `http://localhost/system_information.json`
+                  },
+                  {
+                    name: 'station_information',
+                    url: `http://localhost/station_information.json`
+                  },
+                  {
+                    name: 'station_status',
+                    url: `http://localhost/station_status.json`
+                  },
+                  {
+                    name: 'free_bike_status',
+                    url: `http://localhost/free_bike_status.json`
+                  }
+                ]
+              }
+            }
+          },
+          exists: true,
+          lang: 'en'
+        }
+      ],
+      '2.2',
+      'gbfs',
+      true,
+      {}
+    )
+
+    expect(result).toMatchObject({
+      languages: expect.any(Array),
+      required: true,
+      exists: true,
+      file: 'gbfs.json',
+      hasErrors: false
+    })
+
+    result.languages.forEach(l => {
+      expect(l).toMatchObject({
+        body: expect.any(Object),
+        exists: true,
+        lang: 'en',
+        errors: false
       })
     })
   })
@@ -322,6 +429,117 @@ describe('validation method', () => {
         }),
         files: expect.any(Array)
       })
+    })
+  })
+})
+
+describe('conditional vehicle_types file', () => {
+  let gbfsFeedServer
+
+  beforeAll(async () => {
+    gbfsFeedServer = require('./fixtures/missing_vehicle_types')()
+
+    await gbfsFeedServer.listen()
+
+    return gbfsFeedServer
+  })
+
+  afterAll(() => {
+    return gbfsFeedServer.close()
+  })
+
+  test('should validate feed', () => {
+    const url = `http://${gbfsFeedServer.server.address().address}:${
+      gbfsFeedServer.server.address().port
+    }`
+    const gbfs = new GBFS(`${url}/gbfs.json`)
+
+    return gbfs.validation().then(result => {
+      // console.log(
+      //   require('util').inspect(result, { depth: null, colors: true })
+      // )
+      // expect(result).toMatchObject({
+      //   summary: expect.objectContaining({
+      //     version: { detected: '2.2', validated: '2.2' },
+      //     hasErrors: true,
+      //     errorsCount: 1
+      //   }),
+      //   files: expect.any(Array)
+      // })
+    })
+  })
+})
+
+describe('conditional required vehicle_type_id', () => {
+  let gbfsFeedServer
+
+  beforeAll(async () => {
+    gbfsFeedServer = require('./fixtures/conditionnal_vehicle_type_id')()
+
+    await gbfsFeedServer.listen()
+
+    return gbfsFeedServer
+  })
+
+  afterAll(() => {
+    return gbfsFeedServer.close()
+  })
+
+  test('should validate feed', () => {
+    const url = `http://${gbfsFeedServer.server.address().address}:${
+      gbfsFeedServer.server.address().port
+    }`
+    const gbfs = new GBFS(`${url}/gbfs.json`)
+
+    return gbfs.validation().then(result => {
+      // console.log(
+      //   require('util').inspect(result, { depth: null, colors: true })
+      // )
+      // expect(result).toMatchObject({
+      //   summary: expect.objectContaining({
+      //     version: { detected: '2.2', validated: '2.2' },
+      //     hasErrors: true,
+      //     errorsCount: 2
+      //   }),
+      //   files: expect.any(Array)
+      // })
+    })
+  })
+})
+
+describe('conditional no required vehicle_type_id', () => {
+  let gbfsFeedServer
+
+  beforeAll(async () => {
+    gbfsFeedServer = require('./fixtures/conditionnal_no_vehicle_type_id')()
+
+    await gbfsFeedServer.listen()
+
+    return gbfsFeedServer
+  })
+
+  afterAll(() => {
+    return gbfsFeedServer.close()
+  })
+
+  test('should validate feed', () => {
+    const url = `http://${gbfsFeedServer.server.address().address}:${
+      gbfsFeedServer.server.address().port
+    }`
+    const gbfs = new GBFS(`${url}/gbfs.json`)
+
+    return gbfs.validation().then(result => {
+      // console.log(
+      //   require('util').inspect(result, { depth: null, colors: true })
+      // )
+      // expect(result).toMatchObject({
+      //   summary: expect.objectContaining({
+      //     version: { detected: '2.2', validated: '2.2' },
+      //     hasErrors: true,
+      //     errorsCount: 1
+      //   }),
+      //   files: expect.any(Array)
+      // })
     })
   })
 })

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "ajv": "^8.5.0",
     "ajv-formats": "^2.1.0",
+    "ajv-merge-patch": "^5.0.1",
     "got": "^11.8.2"
   },
   "devDependencies": {

--- a/gbfs-validator/schema/v2.2/partials/no_required_vehicle_type_id.js
+++ b/gbfs-validator/schema/v2.2/partials/no_required_vehicle_type_id.js
@@ -1,0 +1,17 @@
+module.exports = () => ({
+  $id: 'no_required_vehicle_type_id.json#',
+  $patch: {
+    source: {
+      $ref:
+        'https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson'
+    },
+    with: [
+      {
+        op: 'add',
+        path:
+          '/properties/data/properties/bikes/items/properties/vehicle_type_id',
+        value: false // @TODO
+      }
+    ]
+  }
+})

--- a/gbfs-validator/schema/v2.2/partials/required_vehicle_type_id.js
+++ b/gbfs-validator/schema/v2.2/partials/required_vehicle_type_id.js
@@ -1,0 +1,53 @@
+module.exports = ({ vehicleTypes }) => ({
+  $id: 'required_vehicle_type_id.json#',
+  $merge: {
+    source: {
+      $ref:
+        'https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson'
+    },
+    with: {
+      properties: {
+        data: {
+          properties: {
+            bikes: {
+              items: {
+                if: {
+                  properties: {
+                    vehicle_type_id: {
+                      enum: vehicleTypes
+                        .filter(vt =>
+                          [
+                            'electric_assist',
+                            'electric',
+                            'combustion'
+                          ].includes(vt.propulsion_type)
+                        )
+                        .map(vt => vt.vehicle_type_id)
+                    }
+                  },
+                  required: ['vehicle_type_id']
+                },
+                then: {
+                  required: ['current_range_meters']
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  $patch: {
+    source: {
+      $ref:
+        'https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson'
+    },
+    with: [
+      {
+        op: 'add',
+        path: '/properties/data/properties/bikes/items/required/0',
+        value: 'vehicle_type_id'
+      }
+    ]
+  }
+})

--- a/gbfs-validator/validate.js
+++ b/gbfs-validator/validate.js
@@ -1,11 +1,16 @@
 const Ajv = require('ajv')
 const addFormats = require('ajv-formats')
+const mergePatch = require('ajv-merge-patch')
 
-module.exports = function validate(schema, object) {
-  const ajv = new Ajv({ allErrors: true })
+module.exports = function validate(schema, object, options = {}) {
+  const ajv = new Ajv({ allErrors: true, strict: false })
   addFormats(ajv)
+  mergePatch(ajv)
 
-  const validate = ajv.compile(schema)
+  let validate = options.addSchema
+    ? ajv.addSchema(schema).compile(options.addSchema)
+    : ajv.compile(schema)
+
   const valid = validate(object)
   // console.log(object, valid, validate.errors)
   return valid ? false : validate.errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,14 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
+ajv-merge-patch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-merge-patch/-/ajv-merge-patch-5.0.1.tgz#0aba921a2ea8632813478aa3d039d8134b58f876"
+  integrity sha512-0UP3aJCzfzBOkmLR+EinJDCfg6DNtprj3bVPo7JJNgUpZMKt097t9xxQOWFGRoB4JvKKIHE2qe0HkVaS/HyrjQ==
+  dependencies:
+    fast-json-patch "^2.0.6"
+    json-merge-patch "^1.0.2"
+
 ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -4779,6 +4787,13 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-json-patch@^2.0.6:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-2.2.1.tgz#18150d36c9ab65c7209e7d4eb113f4f8eaabe6d9"
+  integrity sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -6846,6 +6861,13 @@ json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-merge-patch@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-merge-patch/-/json-merge-patch-1.0.2.tgz#c4626811943b2f362f8607ae8f03d528875465b0"
+  integrity sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

On `free_bike_status.json`
+ `vehicle_type_id` if has a `vehicle_types.json`
+ `current_range_meters` if the vehicle_type_id has not the `human` propulsion

Set `vehicle_types.json` required if `free_bike_status.json` has `vehicle_type_id`

issue #54

## Updates (in todo)

I made a major change on the core.
Before, for each file we download the body then validate it individualy (with `checkFile` func).
Now, we download  all files (`getFile`), then after validate it (`validationFile`). In this way, we can include conditionnal / additionnal validation.

### Schemas with dynamic parts

I kept in mind to try keeping json schemas untouched. They are intended to be defined in a remote repository (https://github.com/MobilityData/gbfs-json-schema) and only linked into the validation.
Some conditional validations (like the `current_range_meters`  requirement if the `propulsion` of  the `vehicle_type_id` is not `human`) seems not possible on json-schema and generic for all feeds.
To be able to validated it, i "augment" (patch/merge) the json-schema with partials (see https://github.com/MobilityData/gbfs-validator/tree/conditionnal-requirement-54/gbfs-validator/schema/v2.2/partials) dynamically generated for the current feed.



