### PR TITLE
Do not try to validate `gbfs_versions` on v1.0

### DIFF
--- a/gbfs-validator/versions/v1.0.js
+++ b/gbfs-validator/versions/v1.0.js
@@ -2,7 +2,6 @@ module.exports = {
   gbfsRequired: false,
   files: options => {
     return [
-      { file: 'gbfs_versions', required: false },
       { file: 'system_information', required: true },
       { file: 'station_information', required: options.docked },
       { file: 'station_status', required: options.docked },


### PR DESCRIPTION
Fix #80