### PR TITLE
chore: Upgrade node version to 18

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.4.0
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Run tests
         run: yarn install && yarn workspaces run test

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To build the project locally, you need
 
 We recommend you to use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating)
 
-You should use `v12.x.x` of Node.js, or higher. We recommend `v14.x.x`.
+Minimum Node.js version `v14.x.x`, or higher. Recommend Node.js version `v18.x.x`.
 
 ## Clone the repository
 

--- a/gbfs-validator/__test__/cli.test.js
+++ b/gbfs-validator/__test__/cli.test.js
@@ -1,3 +1,8 @@
+const serverOpts = {
+  port: 0,
+  host: '127.0.0.1',
+}
+
 describe('cli', () => {
   describe('without arguments', () => {
     test('should show help without required url', async () => {
@@ -20,7 +25,7 @@ describe('cli', () => {
     beforeAll(async () => {
       gbfsFeedServer = require('./fixtures/server')()
 
-      await gbfsFeedServer.listen()
+      await gbfsFeedServer.listen(serverOpts)
 
       return gbfsFeedServer
     })

--- a/gbfs-validator/__test__/fixtures/server.js
+++ b/gbfs-validator/__test__/fixtures/server.js
@@ -1,7 +1,11 @@
 const fastify = require('fastify')
 
 function build(opts = {}) {
-  const app = fastify(opts)
+  const app = fastify({
+    ...opts,
+    port: opts?.port || 0,
+    host: opts?.host || 'localhost'
+  })
 
   app.get('/gbfs.json', async function(request, reply) {
     return {

--- a/gbfs-validator/__test__/gbfs.test.js
+++ b/gbfs-validator/__test__/gbfs.test.js
@@ -1,5 +1,10 @@
 const GBFS = require('../gbfs')
 
+const serverOpts = {
+  port: 0,
+  host: '127.0.0.1',
+}
+
 describe('initialization', () => {
   test('should correctly initialize validator per default', () => {
     expect(new GBFS('http://localhost:8888/gbfs.json')).toMatchSnapshot()
@@ -55,7 +60,7 @@ describe('checkAutodiscovery method', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/server')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -160,7 +165,7 @@ describe('getFile method', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/server')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -282,7 +287,7 @@ describe('validationFile method', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/server')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -405,7 +410,7 @@ describe('validation method', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/server')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -441,7 +446,7 @@ describe('conditional vehicle_types file', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/missing_vehicle_types')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -481,7 +486,7 @@ describe('conditional required vehicle_type_id', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/conditionnal_vehicle_type_id')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -538,7 +543,7 @@ describe('conditional no required vehicle_type_id', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/conditionnal_no_vehicle_type_id')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -579,7 +584,7 @@ describe('conditional required vehicle_types_available', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/conditionnal_vehicle_types_available')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })
@@ -623,7 +628,7 @@ describe('conditional plan_id', () => {
   beforeAll(async () => {
     gbfsFeedServer = require('./fixtures/plan_id')()
 
-    await gbfsFeedServer.listen()
+    await gbfsFeedServer.listen(serverOpts)
 
     return gbfsFeedServer
   })


### PR DESCRIPTION
# Summary

Resolves #96 

This PR upgrades the node version to 18, the latest LTS as of now(_April 2023_). After upgrading the node version noticed unit tests failing due to issues processing IPv6 localhost at GitHub in the actions. Fixed the test forcing the use of `127.0.0.1` as a host while running unit tests.

# Expected behavior

- Node version minimum version is set to _14_ and recommended to 18 on the README file.
- GitHub actions node version set to 18
-  Unit tests pass successfully 