### PR TITLE
Add All Contributors Specification

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,13 @@
+{
+  "projectName": "gbfs-validator",
+  "projectOwner": "MobilityData",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "commit": false,
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": true,
+  "skipCi": true,
+  "contributors": []
+}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Open `localhost:8080` on your browser
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-We welcome contributions to the project! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
 
 :warning: for contributions on schemas, please see [Versions README](gbfs-validator/versions/README.md)
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Open `localhost:8080` on your browser
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
+This project follows the [all-contributors](https://allcontributors.org/docs/en/overview) specification, find the [emoji key here](https://allcontributors.org/docs/en/emoji-key). Contributions of any kind welcome! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
 
 :warning: for contributions on schemas, please see [Versions README](gbfs-validator/versions/README.md)
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # GBFS-validator
 
+[![All Contributors](https://img.shields.io/github/all-contributors/MobilityData/gbfs-validator?color=blue&style=flat)](#contributors)
+
 A [General Bikeshare Feed Specification](https://github.com/MobilityData/gbfs) dataset validator
 
-# Introduction
+## Introduction
 
 The Canonical GBFS Validator is a tool to check the conformity of a GBFS feed against the [official specification](https://github.com/MobilityData/gbfs/blob/master/gbfs.md).
 It validates feeds up to GBFS version 2.3.
@@ -14,7 +16,7 @@ The schemas in `gbfs-validator/versions/schemas` is a git subtree of https://git
 
 Questions? Please open an issue or reach out to MobilityData on the GBFS slack channel!
 
-# Run the app
+## Run the app
 
 The validator is developed to be used “online” (hosted with a lambda function).
 
@@ -24,20 +26,14 @@ The validator is developed to be used “online” (hosted with a lambda functio
 4.  Select file requirement options (free-floating or docked)
 5.  Click the “Valid me” button, and see the validation results below
 
-# Validation rules
+## Validation rules
 
 The validation rules are listed in [RULES.md](/RULES.md)
 Have a suggestion for a new rule? Open an issue!
 
-# Contributing
+## Build the project: Web server install procedure
 
-We welcome contributions to the project! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
-
-:warning: for contributions on schemas, please see [Versions README](gbfs-validator/versions/README.md)
-
-# Build the project: Web server install procedure
-
-## Required
+### Required
 
 To build the project locally, you need
 
@@ -45,20 +41,20 @@ To build the project locally, you need
 
 - Ports 8080, 9000 and 9229 need to be free
 
-### Node.js
+#### Node.js
 
 We recommend you to use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating)
 
 Minimum Node.js version `v14.x.x`, or higher. Recommend Node.js version `v18.x.x`.
 
-## Clone the repository
+### Clone the repository
 
 ```shell
 git clone https://github.com/fluctuo/gbfs-validator.git
 cd gbfs-validator
 ```
 
-## Run dev environment
+### Run dev environment
 
 With Node.js
 
@@ -69,10 +65,24 @@ yarn start
 
 Open `localhost:8080` on your browser
 
-# Projects based on this validator
+## Projects based on this validator
 
-[transport.data.gouv.fr GBFS validator tool](https://transport.data.gouv.fr/validation?type=gbfs) - Tool displaying interactive geofencing, station, and vehicle maps, the validation results, and metadata of GBFS feeds.  
+[transport.data.gouv.fr GBFS validator tool](https://transport.data.gouv.fr/validation?type=gbfs) - Tool displaying interactive geofencing, station, and vehicle maps, the validation results, and metadata of GBFS feeds.
 
-# Acknowledgements
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+We welcome contributions to the project! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
+
+:warning: for contributions on schemas, please see [Versions README](gbfs-validator/versions/README.md)
+## Acknowledgements
 
 This project was originally created by Pierrick Paul at [fluctuo](https://fluctuo.com/) - MobilityData started maintaining the project in September 2021.


### PR DESCRIPTION
[All-contributors](https://github.com/all-contributors/all-contributors) is a specification to recognize open source contributors to a project. 

MobilityData wants to test this tool on the gbfs-validator, hopefully adding it to all other open-source projects we host (GTFS and GBFS included). 