### PR TITLE
Fix required boolean (invalid) with required array

### DIFF
--- a/gbfs-validator/versions/schemas/v1.0/gbfs.json
+++ b/gbfs-validator/versions/schemas/v1.0/gbfs.json
@@ -40,9 +40,9 @@
             }
           },
           "required": ["feeds"]
-        },
-        "required": true
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v1.1/gbfs.json
+++ b/gbfs-validator/versions/schemas/v1.1/gbfs.json
@@ -63,12 +63,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v1.1/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v1.1/gbfs_versions.json
@@ -58,9 +58,9 @@
             },
             "required": ["version", "url"]
           }
-        },
-        "required": true
+        }
       },
+      "required": ["versions"],
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v2.0/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.0/gbfs.json
@@ -63,12 +63,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v2.0/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v2.0/gbfs_versions.json
@@ -58,9 +58,9 @@
             },
             "required": ["version", "url"]
           }
-        },
-        "required": true
+        }
       },
+      "required": ["versions"],
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v2.1/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.1/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v2.2/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.2/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v2.3/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.3/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/gbfs-validator/versions/schemas/v3.0-RC/gbfs.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/gbfs.json
@@ -27,6 +27,7 @@
       ]
     },
     "data": {
+      "type": "object",
       "properties": {
         "feeds": {
           "description": "An array of all of the feeds that are published by the auto-discovery file. Each element in the array is an object with the keys below.",
@@ -58,12 +59,12 @@
               }
             },
             "required": ["name", "url"]
-          }
-        },
-        "required": true
-      }
-    },
-    "required": true
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["feeds"]
+    }
   },
   "additionalProperties": false,
   "required": ["last_updated", "ttl", "version", "data"]


### PR DESCRIPTION
## What is it about?
The JSON schema used for GBFS feed validation was using an invalid property. The property `required` must take an array ([reference](https://json-schema.org/understanding-json-schema/reference/object.html#required-properties)) but it was taking a boolean. 

The GBFS JSON schema was fixed in [Replace required with boolean (invalid) to array](https://github.com/MobilityData/gbfs-json-schema/pull/92). 

This PR updates the schema in [gbfs-validator](https://github.com/MobilityData/gbfs-validator).

## Why does it matter?
A provider ([TIER](https://www.tier.app/en/)) is trying to update their GBFS feeds to v3.0, which is great! Unfortunately our validator is not so helpful now because it says the [feed](https://data-sharing.tier-services.io/tier_paris/gbfs/3.0) is valid although it's not. This PR will help the provider fix their feed.

## Screenshots
https://data-sharing.tier-services.io/tier_paris/gbfs/3.0
![image](https://github.com/MobilityData/gbfs-validator/assets/2423604/70d28ef7-f5a7-4368-b5fb-c5b7e251b9f8)

Before | After
-- | --
<img width="1800" alt="image" src="https://github.com/MobilityData/gbfs-validator/assets/2423604/f1c872f2-44ee-4ece-ad91-bdd436700da3"> | <img width="1800" alt="image" src="https://github.com/MobilityData/gbfs-validator/assets/2423604/182080a4-30b1-4577-806f-c3e4285797bc">
The validation report says [gbfs.json](https://data-sharing.tier-services.io/tier_paris/gbfs/3.0) is valid although it is not. | The validation report correctly shows [gbfs.json](https://data-sharing.tier-services.io/tier_paris/gbfs/3.0) as invalid due to the extra `en` level.