### PR TITLE
Adds file type if `manifest.json` file is not found

### DIFF
--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -502,6 +502,7 @@ class GBFS {
           errors: false,
           exists: false,
           file: `manifest.json`,
+          type: 'manifest',
           hasErrors: false
         })
       }


### PR DESCRIPTION
Currently, when `manifest_url` is specified in `system_information.json`, but the file is not found at the URL, the validator fails.
Instead, the validator should inform that the `manifest.json` file is missing.

Fix https://github.com/MobilityData/gbfs-validator/issues/119