### PR TITLE
Remove `minItems` for `vehicle_types_available`

### DIFF
--- a/gbfs-validator/versions/schemas/v2.1/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.1/station_status.json
@@ -47,7 +47,6 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/gbfs-validator/versions/schemas/v2.2/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.2/station_status.json
@@ -47,7 +47,6 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/gbfs-validator/versions/schemas/v2.3/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/station_status.json
@@ -47,7 +47,6 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
@@ -50,7 +50,6 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-validator/issues/123

Tested with this sample feed: https://data.mfdz.de/gbfs/test/gbfs.json

Before | After
-- | --
<img width="1358" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/32070791-c315-4f46-bea5-5c1a784da438"> | <img width="1376" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/07164b7f-f933-442e-a4ba-f05a0aabe8e5">