### PR TITLE
Add "maintained by MobilityData" to the footer

### DIFF
--- a/website/src/components/Footer.vue
+++ b/website/src/components/Footer.vue
@@ -1,7 +1,8 @@
 <template>
   <footer class="footer text-center text-muted mt-5">
-    Made with &hearts; by <a href="http://fluctuo.com">fluctuo</a>, website
-    powered by
+    Made with &hearts; by <a href="http://fluctuo.com">fluctuo</a>, 
+    maintained by <a href="https://mobilitydata.org">MobilityData</a>, 
+    website powered by
     <a href="http://https://www.netlify.com/">netlify </a>
   </footer>
 </template>


### PR DESCRIPTION
Adding "maintained by MobilityData" to the footer with a link to our website, along the lines of what we have on the [GTFS Validator](https://gtfs-validator.mobilitydata.org/)