### PR TITLE
feat: add support for multiple auth headers

### DIFF
--- a/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
+++ b/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
@@ -73,18 +73,55 @@ GBFS {
 }
 `;
 
-exports[`initialization with auth should correctly initialize with \`api_key\` 1`] = `
+exports[`initialization with auth should correctly initialize with one \`headers\` 1`] = `
 GBFS {
   "auth": Object {
-    "apiKey": Object {
-      "key": "mykey",
-      "value": "myvalue",
-    },
-    "type": "api_key",
+    "headers": Array [
+      Object {
+        "key": "mykey",
+        "value": "myvalue",
+      },
+    ],
+    "type": "headers",
   },
   "gotOptions": Object {
     "headers": Object {
       "mykey": "myvalue",
+    },
+  },
+  "options": Object {
+    "docked": false,
+    "freefloating": false,
+    "version": null,
+  },
+  "url": "http://localhost:8888/gbfs.json",
+}
+`;
+
+exports[`initialization with auth should correctly initialize with multiple \`headers\` 1`] = `
+GBFS {
+  "auth": Object {
+    "headers": Array [
+      Object {
+        "key": "mykey",
+        "value": "myvalue",
+      },
+      Object {
+        "key": "mysecondkey",
+        "value": "mysecondvalue",
+      },
+      Object {
+        "key": "mythirdkey",
+        "value": "mythirdvalue",
+      },
+    ],
+    "type": "headers",
+  },
+  "gotOptions": Object {
+    "headers": Object {
+      "mykey": "myvalue",
+      "mysecondkey": "mysecondvalue",
+      "mythirdkey": "mythirdvalue",
     },
   },
   "options": Object {

--- a/gbfs-validator/__test__/gbfs.test.js
+++ b/gbfs-validator/__test__/gbfs.test.js
@@ -52,15 +52,41 @@ describe('initialization', () => {
       ).toMatchSnapshot()
     })
 
-    test('should correctly initialize with `api_key`', () => {
+    test('should correctly initialize with one `headers`', () => {
       expect(
         new GBFS('http://localhost:8888/gbfs.json', {
           auth: {
-            type: 'api_key',
-            apiKey: {
-              key: 'mykey',
-              value: 'myvalue'
-            }
+            type: 'headers',
+            headers: [
+              {
+                key: 'mykey',
+                value: 'myvalue'
+              }
+            ]
+          }
+        })
+      ).toMatchSnapshot()
+    })
+
+    test('should correctly initialize with multiple `headers`', () => {
+      expect(
+        new GBFS('http://localhost:8888/gbfs.json', {
+          auth: {
+            type: 'headers',
+            headers: [
+              {
+                key: 'mykey',
+                value: 'myvalue'
+              },
+              {
+                key: 'mysecondkey',
+                value: 'mysecondvalue'
+              },
+              {
+                key: 'mythirdkey',
+                value: 'mythirdvalue'
+              }
+            ]
           }
         })
       ).toMatchSnapshot()

--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -187,9 +187,12 @@ class GBFS {
         }
       }
 
-      if (this.auth.type === 'api_key' && this.auth.apiKey) {
-        this.gotOptions.headers = {
-          [this.auth.apiKey.key]: `${this.auth.apiKey.value}`
+      if (this.auth.type === 'headers') {
+        this.gotOptions.headers = {}
+        for (var header of this.auth.headers) {
+          if (header && header.value) {
+            this.gotOptions.headers[header.key] = header.value
+          }
         }
       }
     }

--- a/website/src/pages/Validator.vue
+++ b/website/src/pages/Validator.vue
@@ -15,12 +15,12 @@ const state = reactive({
       type: null,
       basicAuth: { user: null, password: null },
       bearerToken: { token: null },
-      apiKey: { key: null },
       oauthClientCredentialsGrant: {
         user: null,
         password: null,
         tokenUrl: null
-      }
+      },
+      headers: [{key: null}, {key: null}, {key: null}]
     }
   },
   versions: [
@@ -36,7 +36,7 @@ const state = reactive({
   auths: [
     {
       value: null,
-      text: 'none'
+      text: 'None'
     },
     {
       value: 'basic_auth',
@@ -47,12 +47,12 @@ const state = reactive({
       text: 'Bearer Token'
     },
     {
-      value: 'api_key',
-      text: 'API Key'
-    },
-    {
       value: 'oauth_client_credentials_grant',
       text: 'Oauth Client Credentials Grant'
+    },
+    {
+      value: 'headers',
+      text: 'Custom Headers (e.g. API Key)'
     }
   ]
 })
@@ -201,25 +201,25 @@ function updateURL() {
             ></b-form-input>
           </b-form-group>
 
-           <b-form-group
-            id="input-group-api_key"
+          <b-form-group
+            id="input-group-headers"
             label="Authentification"
-            label-for="input-api_key"
-            v-if="state.options.auth.type === 'api_key'"
+            label-for="input-headers"
+            v-if="state.options.auth.type === 'headers'"
           >
-            <b-row>
+            <b-row v-for="index in 3" class="mb-2">
               <b-col>
                 <b-form-input
-                  id="input-api_key-key"
+                  :id="'input-headers-' + index + '-key'"
                   placeholder="key"
-                  v-model="state.options.auth.apiKey.key"
+                  v-model="state.options.auth.headers[index-1].key"
                 ></b-form-input>
               </b-col>
               <b-col>
                 <b-form-input
-                  id="input-api_key-value"
+                  :id="'input-headers-' + index + '-value'"
                   placeholder="value"
-                  v-model="state.options.auth.apiKey.value"
+                  v-model="state.options.auth.headers[index-1].value"
                 ></b-form-input>
               </b-col>
             </b-row>


### PR DESCRIPTION
In #118 a feature to add API-Key authentication was added. 

Unfortunately some gateways require more than one key for authentication. To address this, I added a more generic approach to allow other kinds of authentication with multiple headers as well. Hence the renaming to `headers` instead of `api_key`.

I limited it to three headers, since this should be sufficient and won't overload the ui with "add header"-buttons.