### PR TITLE
Fix manifest file validation

### DIFF
--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -493,7 +493,13 @@ class GBFS {
         const body = await got.get(manifestUrl, this.gotOptions).json()
 
         files.push({
-          body,
+          body: [
+            {
+              body,
+              exists: true,
+              url: manifestUrl
+            }
+          ],
           required: true,
           type: 'manifest'
         })


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-validator/issues/142

Before | After
-- | --
![gbfs-validator mobilitydata org_validator_url=https%3A%2F%2Fapi ridecheck app%2Fgbfs%2Fv3%2Famsterdam%2Fgbfs json (1)](https://github.com/MobilityData/gbfs-validator/assets/2423604/29714ef9-f9c3-465f-90ae-ea2fc328986c) | ![localhost_8080_validator_url=https%3A%2F%2Fapi ridecheck app%2Fgbfs%2Fv3%2Famsterdam%2Fgbfs json](https://github.com/MobilityData/gbfs-validator/assets/2423604/125a850a-47e6-484b-b999-1b1f42bd7301)

Test feed for screenshots: https://api.ridecheck.app/gbfs/v3/amsterdam/gbfs.json