### PR TITLE
Updates `available_until` regex to allow timezones

### DIFF
--- a/gbfs-validator/versions/schemas/v2.3/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/free_bike_status.json
@@ -120,7 +120,7 @@
               "available_until": {
                 "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3.",
                 "type": "string",
-                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})([A-Z])$"
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(([+-]([0-9]{2}):([0-9]{2}))|Z)$"
               }
             },
             "anyOf": [

--- a/gbfs-validator/versions/schemas/v3.0-RC/vehicle_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/vehicle_status.json
@@ -123,7 +123,7 @@
               "available_until": {
                 "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3.",
                 "type": "string",
-                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})([A-Z])$"
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(([+-]([0-9]{2}):([0-9]{2}))|Z)$"
               }
             },
             "anyOf": [


### PR DESCRIPTION
This PR syncs the JSON Schemas after the PR https://github.com/MobilityData/gbfs-json-schema/pull/97.

It updates `available_until` regex to allow timezones.

Files are affected by this change:
`v2.3/free_bike_status.json` and `v3.0-RC/vehicle_status.json`