### PR TITLE
fix: netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "website/dist"
 
 [build.environment]
-  YARN_FLAGS = "--frozen-lockfile --ignore-scripts --debug"
+  YARN_FLAGS = "--frozen-lockfile --ignore-scripts/"
 
 [functions]
   directory = "functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "website/dist"
 
 [build.environment]
-  YARN_FLAGS = "--frozen-lockfile --skip-integrity-check --debug"
+  YARN_FLAGS = "--frozen-lockfile --ignore-scripts --debug"
 
 [functions]
   directory = "functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "website/dist"
 
 [build.environment]
-  YARN_FLAGS = "--frozen-lockfile"
+  YARN_FLAGS = "--frozen-lockfile --skip-integrity-check --debug"
 
 [functions]
   directory = "functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "website/dist"
 
 [build.environment]
-  YARN_FLAGS = "--frozen-lockfile --ignore-scripts/"
+  YARN_FLAGS = "--frozen-lockfile --ignore-scripts"
 
 [functions]
   directory = "functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "website/dist"
 
 [build.environment]
-  YARN_FLAGS = "--frozen-lockfile --network-concurrency 1"
+  YARN_FLAGS = "--frozen-lockfile"
 
 [functions]
   directory = "functions"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-vue": "^9.14.1",
-    "netlify-cli": "^15.11.0",
-    "@netlify/edge-bundler": "8.17.1"
+    "netlify-cli": "^15.11.0"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-vue": "^9.14.1",
-    "netlify-cli": "^15.11.0"
+    "netlify-cli": "^15.11.0",
+    "@netlify/edge-bundler": "8.17.1"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
# Description

Netlify build broke after merging to master _mysteriously_. In this PR the yarn post-install scripts are ignored to avoid yarn crashes. This is not ideal as in the future we might add a dependency that uses the post-install pattern like netlify-cli does.