### PR TITLE
Fix authentication typo

### DIFF
--- a/website/src/pages/Validator.vue
+++ b/website/src/pages/Validator.vue
@@ -150,10 +150,10 @@ function updateURL() {
             >
           </b-form-group>
         </b-tab>
-        <b-tab title="Authentification">
+        <b-tab title="Authentication">
           <b-form-group
             id="input-group-auth"
-            label="Authentification"
+            label="Authentication"
             label-for="input-auth"
             class="mb-3"
           >
@@ -166,7 +166,7 @@ function updateURL() {
 
           <b-form-group
             id="input-group-basic_auth"
-            label="Authentification"
+            label="Authentication"
             label-for="input-basic_auth"
             v-if="state.options.auth.type === 'basic_auth'"
           >
@@ -190,7 +190,7 @@ function updateURL() {
 
           <b-form-group
             id="input-group-bearer_token"
-            label="Authentification"
+            label="Authentication"
             label-for="input-bearer_token"
             v-if="state.options.auth.type === 'bearer_token'"
           >
@@ -203,7 +203,7 @@ function updateURL() {
 
           <b-form-group
             id="input-group-headers"
-            label="Authentification"
+            label="Authentication"
             label-for="input-headers"
             v-if="state.options.auth.type === 'headers'"
           >
@@ -227,7 +227,7 @@ function updateURL() {
 
           <b-form-group
             id="input-group-oauth_client_credentials_grant"
-            label="Authentification"
+            label="Authentication"
             label-for="input-bearer_token"
             v-if="state.options.auth.type === 'oauth_client_credentials_grant'"
           >


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-validator/issues/150

Replaces "Authentification" (French) with "Authentication" (English).

Before | After
-- | --
<img width="1195" alt="image" src="https://github.com/MobilityData/gbfs-validator/assets/2423604/6a09b202-b5dd-4168-9de3-f3dbbf772a7f"> | <img width="1395" alt="Screenshot 2023-11-08 at 09 09 05" src="https://github.com/MobilityData/gbfs-validator/assets/2423604/b7ef10b9-316b-48b2-b9cb-35cbef163eb9">