### PR TITLE
Remove redundant formatting in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/new-issue-template.md
@@ -3,8 +3,8 @@ name: New Issue Template
 about: 'Please use this template for all new issues.'
 ---
 
-### **If you are new to the GBFS Validator, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!** 
+### If you are new to the GBFS Validator, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!
 
-### **What is the issue and _why_ is it an issue?**
+### What is the issue and _why_ is it an issue?
 
-### **Please describe some potential solutions you have considered (even if they aren’t related to GBFS).**
+### Please describe some potential solutions you have considered (even if they aren’t related to GBFS).


### PR DESCRIPTION
"###" markdown already applies the bold formatting so "**" is not needed.