### PR TITLE
Update schema id URL from NABSA to MobilityData repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The function is only compatible with Netlify Function (https://www.netlify.com/p
 
 - check-systems
 
-Check-systems is a CLI tool to validate the whole “systems.csv” from https://github.com/NABSA/gbfs locally
+Check-systems is a CLI tool to validate the whole “systems.csv” from https://github.com/MobilityData/gbfs locally
 
 # Code convention
 

--- a/RULES.md
+++ b/RULES.md
@@ -18,12 +18,12 @@ The validator will check for the presence of the files depending on the options 
 <img width="350" alt="tick boxes" src="https://user-images.githubusercontent.com/63653518/156194900-bab75f85-f681-43a4-84d3-08c9d6fed4df.png">
 
 
-The Validator also checks the conditional requirement of the file `vehicle_types.json`: as per the [official GBFS specification](https://github.com/NABSA/gbfs/blob/master/gbfs.md#vehicle_typesjson), it is required of systems that include information about vehicle types in the `vehicle_status.json file`.
+The Validator also checks the conditional requirement of the file `vehicle_types.json`: as per the [official GBFS specification](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_typesjson), it is required of systems that include information about vehicle types in the `vehicle_status.json file`.
 
 
 # Fields presence and field types
 ## Required fields
-Each file in GBFS has to be structured in a specific [output format](https://github.com/NABSA/gbfs/blob/master/gbfs.md#output-format).
+Each file in GBFS has to be structured in a specific [output format](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#output-format).
 All the fields that are described as **required** in GBFS will be checked by the validator.
 Some fields are required only if the parent field is defined, and this is considered a **conditionally required** field.
 
@@ -68,8 +68,8 @@ The following conditions are all covered by this validator:
 `current_range_meters`
 
 - **conditions that are not covered by this validator**
-`num_docks_available` in station_status.json`: because it depends on something that isn't defined in the GBFS files: the docking capacity. See the official GBFS spec about this field [here](https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_statusjson).\
-`vehicle_docks_available` in station_status.json`: because it depends on something that isn't defined in the GBFS files: *REQUIRED in feeds where [...] certain docks are only able to accept certain vehicle types.* See the official GBFS spec about this field [here](https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_statusjson).\
+`num_docks_available` in station_status.json`: because it depends on something that isn't defined in the GBFS files: the docking capacity. See the official GBFS spec about this field [here](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_statusjson).\
+`vehicle_docks_available` in station_status.json`: because it depends on something that isn't defined in the GBFS files: *REQUIRED in feeds where [...] certain docks are only able to accept certain vehicle types.* See the official GBFS spec about this field [here](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_statusjson).\
 `system_id` in `free_bike_status.json`
 
 ## Field types

--- a/check-systems/README.md
+++ b/check-systems/README.md
@@ -1,5 +1,5 @@
 # check-systems
 
-Download systems.csv from https://github.com/NABSA/gbfs
+Download systems.csv from https://github.com/MobilityData/gbfs
 
 `node check-systems/index.js systems.csv`

--- a/gbfs-validator/versions/partials/v2.1/free_bike_status/required_vehicle_type_id.js
+++ b/gbfs-validator/versions/partials/v2.1/free_bike_status/required_vehicle_type_id.js
@@ -11,7 +11,7 @@ module.exports = ({ vehicleTypes }) => {
     partial.$merge = {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson'
       },
       with: {
         properties: {
@@ -49,7 +49,7 @@ module.exports = ({ vehicleTypes }) => {
   partial.$patch = {
     source: {
       $ref:
-        'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson'
+        'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson'
     },
     with: [
       {

--- a/gbfs-validator/versions/partials/v2.1/station_status/required_vehicle_types_available.js
+++ b/gbfs-validator/versions/partials/v2.1/station_status/required_vehicle_types_available.js
@@ -4,7 +4,7 @@ module.exports = ({ vehicleTypes }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_statusjson'
       },
       with: {
         properties: {
@@ -33,7 +33,7 @@ module.exports = ({ vehicleTypes }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_statusjson'
       },
       with: [
         {

--- a/gbfs-validator/versions/partials/v2.1/system_information/required_store_uri.js
+++ b/gbfs-validator/versions/partials/v2.1/system_information/required_store_uri.js
@@ -4,7 +4,7 @@ module.exports = ({ android = false, ios = false }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_informationjson'
       },
       with: [
         {
@@ -17,7 +17,7 @@ module.exports = ({ android = false, ios = false }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_informationjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v2.2/free_bike_status/required_vehicle_type_id.js
+++ b/gbfs-validator/versions/partials/v2.2/free_bike_status/required_vehicle_type_id.js
@@ -11,7 +11,7 @@ module.exports = ({ vehicleTypes }) => {
     partial.$merge = {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson'
       },
       with: {
         properties: {
@@ -49,7 +49,7 @@ module.exports = ({ vehicleTypes }) => {
   partial.$patch = {
     source: {
       $ref:
-        'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson'
+        'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson'
     },
     with: [
       {

--- a/gbfs-validator/versions/partials/v2.2/station_status/required_vehicle_types_available.js
+++ b/gbfs-validator/versions/partials/v2.2/station_status/required_vehicle_types_available.js
@@ -4,7 +4,7 @@ module.exports = ({ vehicleTypes }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_statusjson'
       },
       with: {
         properties: {
@@ -33,7 +33,7 @@ module.exports = ({ vehicleTypes }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_statusjson'
       },
       with: [
         {

--- a/gbfs-validator/versions/partials/v2.2/system_information/required_store_uri.js
+++ b/gbfs-validator/versions/partials/v2.2/system_information/required_store_uri.js
@@ -4,7 +4,7 @@ module.exports = ({ android = false, ios = false }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_informationjson'
       },
       with: [
         {
@@ -17,7 +17,7 @@ module.exports = ({ android = false, ios = false }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_informationjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v2.3/free_bike_status/required_vehicle_type_id.js
+++ b/gbfs-validator/versions/partials/v2.3/free_bike_status/required_vehicle_type_id.js
@@ -11,7 +11,7 @@ module.exports = ({ vehicleTypes }) => {
     partial.$merge = {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson'
       },
       with: {
         properties: {
@@ -49,7 +49,7 @@ module.exports = ({ vehicleTypes }) => {
   partial.$patch = {
     source: {
       $ref:
-        'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson'
+        'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson'
     },
     with: [
       {

--- a/gbfs-validator/versions/partials/v2.3/station_status/required_vehicle_types_available.js
+++ b/gbfs-validator/versions/partials/v2.3/station_status/required_vehicle_types_available.js
@@ -4,7 +4,7 @@ module.exports = ({ vehicleTypes }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_statusjson'
       },
       with: {
         properties: {
@@ -33,7 +33,7 @@ module.exports = ({ vehicleTypes }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_statusjson'
       },
       with: [
         {

--- a/gbfs-validator/versions/partials/v2.3/system_information/required_store_uri.js
+++ b/gbfs-validator/versions/partials/v2.3/system_information/required_store_uri.js
@@ -4,7 +4,7 @@ module.exports = ({ android = false, ios = false }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_informationjson'
       },
       with: [
         {
@@ -17,7 +17,7 @@ module.exports = ({ android = false, ios = false }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_informationjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v2.3/vehicle_types/pricing_plan_id.js
+++ b/gbfs-validator/versions/partials/v2.3/vehicle_types/pricing_plan_id.js
@@ -4,7 +4,7 @@ module.exports = ({ pricingPlans }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#vehicle_typesjson-added-in-v21-rc'
+          'https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#vehicle_typesjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v3.0-RC/station_status/required_vehicle_types_available.js
+++ b/gbfs-validator/versions/partials/v3.0-RC/station_status/required_vehicle_types_available.js
@@ -4,7 +4,7 @@ module.exports = ({ vehicleTypes }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson'
       },
       with: {
         properties: {
@@ -33,7 +33,7 @@ module.exports = ({ vehicleTypes }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson'
       },
       with: [
         {

--- a/gbfs-validator/versions/partials/v3.0-RC/system_information/required_store_uri.js
+++ b/gbfs-validator/versions/partials/v3.0-RC/system_information/required_store_uri.js
@@ -4,7 +4,7 @@ module.exports = ({ android = false, ios = false }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson'
       },
       with: [
         {
@@ -17,7 +17,7 @@ module.exports = ({ android = false, ios = false }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v3.0-RC/vehicle_status/required_vehicle_type_id.js
+++ b/gbfs-validator/versions/partials/v3.0-RC/vehicle_status/required_vehicle_type_id.js
@@ -11,7 +11,7 @@ module.exports = ({ vehicleTypes }) => {
     partial.$merge = {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson'
       },
       with: {
         properties: {
@@ -49,7 +49,7 @@ module.exports = ({ vehicleTypes }) => {
   partial.$patch = {
     source: {
       $ref:
-        'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson'
+        'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson'
     },
     with: [
       {

--- a/gbfs-validator/versions/partials/v3.0-RC/vehicle_types/pricing_plan_id.js
+++ b/gbfs-validator/versions/partials/v3.0-RC/vehicle_types/pricing_plan_id.js
@@ -4,7 +4,7 @@ module.exports = ({ pricingPlans }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson-added-in-v21-rc'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v3.0-RC2/station_status/required_vehicle_types_available.js
+++ b/gbfs-validator/versions/partials/v3.0-RC2/station_status/required_vehicle_types_available.js
@@ -4,7 +4,7 @@ module.exports = ({ vehicleTypes }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson'
       },
       with: {
         properties: {
@@ -33,7 +33,7 @@ module.exports = ({ vehicleTypes }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson'
       },
       with: [
         {

--- a/gbfs-validator/versions/partials/v3.0-RC2/system_information/required_store_uri.js
+++ b/gbfs-validator/versions/partials/v3.0-RC2/system_information/required_store_uri.js
@@ -4,7 +4,7 @@ module.exports = ({ android = false, ios = false }) => {
     $patch: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson'
       },
       with: [
         {
@@ -17,7 +17,7 @@ module.exports = ({ android = false, ios = false }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/partials/v3.0-RC2/vehicle_status/required_vehicle_type_id.js
+++ b/gbfs-validator/versions/partials/v3.0-RC2/vehicle_status/required_vehicle_type_id.js
@@ -11,7 +11,7 @@ module.exports = ({ vehicleTypes }) => {
     partial.$merge = {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson'
       },
       with: {
         properties: {
@@ -49,7 +49,7 @@ module.exports = ({ vehicleTypes }) => {
   partial.$patch = {
     source: {
       $ref:
-        'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson'
+        'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson'
     },
     with: [
       {

--- a/gbfs-validator/versions/partials/v3.0-RC2/vehicle_types/pricing_plan_id.js
+++ b/gbfs-validator/versions/partials/v3.0-RC2/vehicle_types/pricing_plan_id.js
@@ -4,7 +4,7 @@ module.exports = ({ pricingPlans }) => {
     $merge: {
       source: {
         $ref:
-          'https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc'
+          'https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_typesjson'
       },
       with: {
         properties: {

--- a/gbfs-validator/versions/schemas/v1.0/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v1.0/free_bike_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#free_bike_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#free_bike_statusjson",
   "description": "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/gbfs.json
+++ b/gbfs-validator/versions/schemas/v1.0/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#gbfsjson",
   "description": "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/station_information.json
+++ b/gbfs-validator/versions/schemas/v1.0/station_information.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#station_informationjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#station_informationjson",
   "description": "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/station_status.json
+++ b/gbfs-validator/versions/schemas/v1.0/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#station_statusjson",
   "description": "Describes the capacity and rental availability of the station",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_alertsjson",
   "description": 	"Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -60,6 +60,7 @@
               "station_ids": {
                 "description": "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -67,6 +68,7 @@
               "region_ids": {
                 "description": "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v1.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_alerts.json
@@ -60,7 +60,6 @@
               "station_ids": {
                 "description": "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -68,7 +67,6 @@
               "region_ids": {
                 "description": "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v1.0/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_calendar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_calendarjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/system_hours.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/system_information.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_information.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_informationjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_informationjson",
   "description": "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_pricing_plans.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_pricing_plansjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.0/system_regions.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_regionsjson",
   "description": "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.1/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v1.1/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are not at a station and are available for rent.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/gbfs.json
+++ b/gbfs-validator/versions/schemas/v1.1/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files publiished by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v1.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#gbfs_versionsjson-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/station_information.json
+++ b/gbfs-validator/versions/schemas/v1.1/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/station_status.json
+++ b/gbfs-validator/versions/schemas/v1.1/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availablility of the station",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v1.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v1.1/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.1/system_hours.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.1/system_information.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v1.1/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v1.1/system_regions.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v1.1/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v2.0/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are not at a station and are available for rent.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.0/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files publiished by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v2.0/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#gbfs_versionsjson-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/station_information.json
+++ b/gbfs-validator/versions/schemas/v2.0/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.0/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availablility of the station",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.0/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.0/system_hours.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.0/system_information.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.0/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.0/system_regions.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v2.1/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.1/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v2.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#gbfs_versionsjson-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-  "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#geofencing_zonesjson",
+  "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#geofencing_zonesjson",
   "description":
   "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
@@ -80,6 +80,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description":
                               "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
@@ -80,7 +80,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description":
                               "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.1/station_information.json
+++ b/gbfs-validator/versions/schemas/v2.1/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.1/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.1/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.1/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.1/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.1/system_hours.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.1/system_information.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.1/system_regions.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.1/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v2.1/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.1/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#vehicle_typesjson-added-in-v21",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v2.2/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.2/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v2.2/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#gbfs_versionsjson-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
@@ -80,7 +80,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description":
                                 "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#geofencing_zonesjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#geofencing_zonesjson",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
@@ -80,6 +80,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description":
                                 "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.2/station_information.json
+++ b/gbfs-validator/versions/schemas/v2.2/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.2/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.2/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.2/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.2/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.2/system_hours.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.2/system_information.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.2/system_regions.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.2/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v2.2/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#vehicle_typesjson-added-in-v21",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/free_bike_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/gbfs.json
+++ b/gbfs-validator/versions/schemas/v2.3/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v2.3/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#gbfs_versionsjson",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
@@ -73,7 +73,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },

--- a/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#geofencing_zonesjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#geofencing_zonesjson",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
@@ -73,6 +73,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },

--- a/gbfs-validator/versions/schemas/v2.3/station_information.json
+++ b/gbfs-validator/versions/schemas/v2.3/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.3/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.3/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.3/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.3/system_calendar.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.3/system_hours.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.3/system_information.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v2.3/system_regions.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#vehicle_typesjson",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
@@ -177,6 +177,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
@@ -177,7 +177,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/gbfs.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#gbfs_versionsjson",
   "description": "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
@@ -91,7 +91,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -168,7 +167,6 @@
             "properties": {
               "vehicle_type_id": {
                 "type": "array",
-                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#geofencing_zonesjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#geofencing_zonesjson",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
@@ -91,6 +91,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -167,6 +168,7 @@
             "properties": {
               "vehicle_type_id": {
                 "type": "array",
+                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC/manifest.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#manifestjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#manifestjson",
   "description": "An index of gbfs.json URLs for each GBFS data set produced by a publisher. A single instance of this file should be published at a single stable URL, for example: https://example.com/gbfs/manifest.json.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC/station_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -115,6 +115,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
@@ -115,7 +115,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -74,6 +74,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -82,6 +83,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
@@ -74,7 +74,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -83,7 +82,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_regions.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC/vehicle_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/vehicle_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v3.0-RC, formerly free_bike_status).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
@@ -244,6 +244,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
@@ -244,7 +244,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/gbfs.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#gbfsjson",
   "description": "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC2/gbfs_versions.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/gbfs_versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#gbfs_versionsjson-added-in-v11",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#gbfs_versionsjson",
   "description": "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
@@ -84,7 +84,6 @@
                           "properties": {
                             "vehicle_type_ids": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -163,7 +162,6 @@
             "properties": {
               "vehicle_type_ids": {
                 "type": "array",
-                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#geofencing_zonesjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#geofencing_zonesjson",
   "description": "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
   "properties": {
@@ -84,6 +84,7 @@
                           "properties": {
                             "vehicle_type_ids": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -162,6 +163,7 @@
             "properties": {
               "vehicle_type_ids": {
                 "type": "array",
+                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC2/manifest.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#manifestjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#manifestjson",
   "description": "An index of gbfs.json URLs for each GBFS data set produced by a publisher. A single instance of this file should be published at a single stable URL, for example: https://example.com/gbfs/manifest.json.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#station_informationjson",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",
@@ -200,6 +200,7 @@
                     "vehicle_type_ids": {
                       "description": "The vehicle_type_ids, as defined in vehicle_types.json, that may park at the virtual station.",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }
@@ -222,6 +223,7 @@
                     "vehicle_type_ids": {
                       "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station.",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
@@ -200,7 +200,6 @@
                     "vehicle_type_ids": {
                       "description": "The vehicle_type_ids, as defined in vehicle_types.json, that may park at the virtual station.",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }
@@ -223,7 +222,6 @@
                     "vehicle_type_ids": {
                       "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station.",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
@@ -116,7 +116,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -116,6 +116,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -75,6 +75,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -83,6 +84,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
@@ -75,7 +75,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -84,7 +83,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_pricing_plans.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_regions.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v3.0-RC, formerly free_bike_status).",
   "type": "object",

--- a/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/MobilityData/gbfs/blob/v3.0-RC2/gbfs.md#vehicle_typesjson",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
@@ -245,6 +245,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
@@ -245,7 +245,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/website/src/components/Result.vue
+++ b/website/src/components/Result.vue
@@ -37,7 +37,7 @@ const errorsCountFormated = computed(() => {
             Detected version <b>{{ result.summary.version.detected }} </b> and
             validate with
             <a
-              :href="`https://github.com/NABSA/gbfs/blob/v${result.summary.version.validated}/gbfs.md`"
+              :href="`https://github.com/MobilityData/gbfs/blob/v${result.summary.version.validated}/gbfs.md`"
               ><b>{{ result.summary.version.validated }}</b></a
             >
           </b-alert>


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-json-schema/issues/101

This PR updates the schema id URLs from NABSA to MobilityData repo and fixes the anchors:

Before | After
-- | --
`"https://github.com/NABSA/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson-added-in-v21-rc"`, | `"https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md#vehicle_typesjson"`~~-added-in-v21-rc~~,