### PR TITLE
Validate uniqueness of values in Arrays of IDs

### DIFF
--- a/gbfs-validator/versions/schemas/v1.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.0/system_alerts.json
@@ -60,6 +60,7 @@
               "station_ids": {
                 "description": "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -67,6 +68,7 @@
               "region_ids": {
                 "description": "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v1.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v1.1/system_alerts.json
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.0/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.0/system_alerts.json
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.1/geofencing_zones.json
@@ -80,6 +80,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description":
                               "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.1/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.1/station_status.json
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.1/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.1/system_alerts.json
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.2/geofencing_zones.json
@@ -80,6 +80,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description":
                                 "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/gbfs-validator/versions/schemas/v2.2/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.2/station_status.json
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.2/system_alerts.json
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v2.3/geofencing_zones.json
@@ -73,6 +73,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },

--- a/gbfs-validator/versions/schemas/v2.3/station_status.json
+++ b/gbfs-validator/versions/schemas/v2.3/station_status.json
@@ -112,6 +112,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v2.3/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v2.3/system_alerts.json
@@ -71,6 +71,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -79,6 +80,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v2.3/vehicle_types.json
@@ -177,6 +177,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/geofencing_zones.json
@@ -91,6 +91,7 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -167,6 +168,7 @@
             "properties": {
               "vehicle_type_id": {
                 "type": "array",
+                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/station_status.json
@@ -115,6 +115,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/system_alerts.json
@@ -74,6 +74,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -82,6 +83,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC/vehicle_types.json
@@ -244,6 +244,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/geofencing_zones.json
@@ -84,6 +84,7 @@
                           "properties": {
                             "vehicle_type_ids": {
                               "type": "array",
+                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -162,6 +163,7 @@
             "properties": {
               "vehicle_type_ids": {
                 "type": "array",
+                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_information.json
@@ -200,6 +200,7 @@
                     "vehicle_type_ids": {
                       "description": "The vehicle_type_ids, as defined in vehicle_types.json, that may park at the virtual station.",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }
@@ -222,6 +223,7 @@
                     "vehicle_type_ids": {
                       "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station.",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/station_status.json
@@ -116,6 +116,7 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
+                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/system_alerts.json
@@ -75,6 +75,7 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -83,6 +84,7 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
+++ b/gbfs-validator/versions/schemas/v3.0-RC2/vehicle_types.json
@@ -245,6 +245,7 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }


### PR DESCRIPTION
JSON Schema sync after https://github.com/MobilityData/gbfs-json-schema/pull/102

Example of vehicle_types.json file with with duplicate ids in the field `vehicle_types.pricing_plan_ids`:
```
"pricing_plan_ids": ["1-standard", "1-standard"]
```

Before | After
-- | --
<img width="1368" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/7243532f-fa68-4d7c-a9aa-3efb2f40fc54"> | <img width="1379" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/e5fae75e-61d9-45bf-bb14-e92fac79cdca">