### PR TITLE
fix: Modified to display that there is an error if a required file is missing

### DIFF
--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -27,38 +27,57 @@ const validatorVersion = process.env.COMMIT_REF
 *          }} VehicleType
 */
 
-  /**
- * This function returns true if the file from a GBFS feed has errors or if the file is required and missing.
- * @param {Object} data - The body of a file from a GBFS feed.
- * @param {boolean} required - True if the file is required.
+/**
+ * Look into the array of files data and return true if any has an error.
+ * @param {FileValidationResult[]} files A list of files data to check for errors.
+ * @returns {boolean} True if any of the files has an error.
+ */
+function filesHaveErrors(files) {
+  if (Array.isArray(files)) {
+    return files.some((file) => hasErrors(file, file.required));
+  }
+  // If the argument is not an array of file data, we'll say there is no error
+  return false;
+}
+
+/**
+ * Return true if the file data from a GBFS feed has errors or if the file is required and missing.
+ * The file data can be an array (e.g. for multi-language) or directly the body from the file.
+ * @param {Object} data - The body of a file data from a GBFS feed.
  * @returns {boolean}
  */
-function hasErrors(data, required) {
-  let hasError = false
+function fileHasErrors(fileData, required) {
+  if (fileHasMultiLanguages(fileData)) {
+    return fileData.some((languageBody) => hasErrors(languageBody, required))
+  }
+  // So it's not a multi-language array, just check the data directly.
+  return hasErrors(fileData, required)
+}
 
-  for (let i = 0; i < data.length; i++) {
-    const el = data[i];
-
-    if (Array.isArray(el)) {
-      if (hasErrors(el, required)) {
-        return true
-      }
-    } else {
-      if (typeof required === 'undefined') {
-        // If the required boolean is not specified, use the required of each individual file
-        if (el.required && !el.exists) {
-          return true
-        }
-      } else if (required && !el.exists) {
-        return true
-      }
-      // At this point we know there are no errors because a required file does not exists. Now check for json errors
-      if (!!el.errors || el.hasErrors) {
-        return true
-      }
-    }
+/**
+ * This function returns true if the file data from a GBFS feed has errors or if the file is required and missing.
+ * Note that a file data cannot be an array for multi-languages.
+ * @param {Object} data - The body of a file data from a GBFS feed.
+ * @returns {boolean}
+ */
+function hasErrors(fileData, required) {
+  if (required && !fileData.exists) {
+    return true
+  }
+  if (!!fileData.errors || fileData.hasErrors) {
+    return true
   }
   return false
+}
+
+/**
+  * This function returns true if the file data from a GBFS feed is an multi-language array of file data.
+  * @param {Object} data - The body of a file data from a GBFS feed.
+  * @returns {boolean}
+  */
+function fileHasMultiLanguages(fileData) {
+  // Currently the only way we know it's multi-language is if it's an array
+  return Array.isArray(fileData)
 }
 
 /**
@@ -532,7 +551,7 @@ class GBFS {
           ? body.reduce((acc, l) => acc && l.exists, true)
           : false,
         file: `${type}.json`,
-        hasErrors: hasErrors(body, required)
+        hasErrors: fileHasErrors(body, required)
       }
     } else {
       return {
@@ -801,7 +820,7 @@ class GBFS {
           detected: result[0].version,
           validated: this.options.version || result[0].version
         },
-        hasErrors: hasErrors(result),
+        hasErrors: filesHaveErrors(result),
         errorsCount: filesResult.reduce((acc, file) => {
           acc += file.errorsCount
           return acc

--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -36,19 +36,29 @@ const validatorVersion = process.env.COMMIT_REF
 function hasErrors(data, required) {
   let hasError = false
 
-  data.forEach((el) => {
+  for (let i = 0; i < data.length; i++) {
+    const el = data[i];
+
     if (Array.isArray(el)) {
       if (hasErrors(el, required)) {
-        hasError = true
+        return true
       }
     } else {
-      if (required && !el.exists ? true : !!el.errors || el.hasErrors) {
-        hasError = true
+      if (typeof required === 'undefined') {
+        // If the required boolean is not specified, use the required of each individual file
+        if (el.required && !el.exists) {
+          return true
+        }
+      } else if (required && !el.exists) {
+        return true
+      }
+      // At this point we know there are no errors because a required file does not exists. Now check for json errors
+      if (!!el.errors || el.hasErrors) {
+        return true
       }
     }
-  })
-
-  return hasError
+  }
+  return false
 }
 
 /**

--- a/website/src/components/Result.vue
+++ b/website/src/components/Result.vue
@@ -45,7 +45,9 @@ const errorsCountFormated = computed(() => {
           <div>
             <b-alert v-if="result.summary.hasErrors" variant="danger" show>
               Invalid GBFS feed <br />
-              <b>{{ errorsCountFormated }} errors</b>
+              <!-- hasErrors can be json errors or required file presence errors. errorsCountFormated is only json errors.
+              We want to display that the feed is invalid in all cases but not the number of errors if it's 0. -->
+              <b v-if="errorsCountFormated > 0">{{ errorsCountFormated }} errors</b>
             </b-alert>
             <b-alert v-else variant="success" show>Valid !</b-alert>
           </div>


### PR DESCRIPTION
Closes #127 
Modified to display `Invalid GBFS feed` if a required file is missing.

Here is the results when using [this feed](https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/gbfs.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx)

![image](https://github.com/MobilityData/gbfs-validator/assets/106176106/d579fa51-82bf-4128-9ec9-ad0ef29733ab)
