### PR TITLE
fix: Error count on missing required files

### DIFF
--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -48,6 +48,9 @@ function filesHaveErrors(files) {
  */
 function fileHasErrors(fileData, required) {
   if (fileHasMultiLanguages(fileData)) {
+    if(fileData.length === 0 && required) {
+      return true;
+    }
     return fileData.some((languageBody) => hasErrors(languageBody, required))
   }
   // So it's not a multi-language array, just check the data directly.
@@ -61,7 +64,7 @@ function fileHasErrors(fileData, required) {
  * @returns {boolean}
  */
 function hasErrors(fileData, required) {
-  if (required && !fileData.exists) {
+  if (required && (!fileData || !fileData.exists)) {
     return true
   }
   if (!!fileData.errors || fileData.hasErrors) {
@@ -87,6 +90,10 @@ function fileHasMultiLanguages(fileData) {
  */
 function countErrors(file) {
   let count = 0
+
+  if(file.required && !file.exists) {
+    count++;
+  }
 
   if (file.hasErrors) {
     if (file.errors) {


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-validator/issues/170 (follow up of https://github.com/MobilityData/gbfs-validator/issues/127)

When a file is required, but it's missing it will now show up in the error count of the file and in the summary

Before
![image](https://github.com/MobilityData/gbfs-validator/assets/18631060/b46de1e6-3185-40e2-a155-e5a9bb07238b)

After
![image](https://github.com/MobilityData/gbfs-validator/assets/18631060/2f620c41-4d7f-440c-b398-b7d3867e85e9)

Tested using this feed: https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/gbfs.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx
