### PR TITLE
fix: validate granada feed through new GOT user-agent

### DIFF
--- a/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
+++ b/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
@@ -2,9 +2,13 @@
 
 exports[`initialization should correctly initialize validator per default 1`] = `
 GBFS {
-  "auth": Object {},
-  "gotOptions": Object {},
-  "options": Object {
+  "auth": {},
+  "gotOptions": {
+    "headers": {
+      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+    },
+  },
+  "options": {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -15,9 +19,13 @@ GBFS {
 
 exports[`initialization should correctly initialize validator with options 1`] = `
 GBFS {
-  "auth": Object {},
-  "gotOptions": Object {},
-  "options": Object {
+  "auth": {},
+  "gotOptions": {
+    "headers": {
+      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+    },
+  },
+  "options": {
     "docked": true,
     "freefloating": true,
     "version": "v2.1",
@@ -30,19 +38,19 @@ exports[`initialization should throw an error without url 1`] = `"Missing URL"`;
 
 exports[`initialization with auth should correctly initialize with \`basic_auth\` 1`] = `
 GBFS {
-  "auth": Object {
-    "basicAuth": Object {
+  "auth": {
+    "basicAuth": {
       "password": "mypassword",
       "user": "myuser",
     },
     "type": "basic_auth",
   },
-  "gotOptions": Object {
-    "headers": Object {
+  "gotOptions": {
+    "headers": {
       "Authorization": "basic bXl1c2VyOm15cGFzc3dvcmQ=",
     },
   },
-  "options": Object {
+  "options": {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -53,43 +61,18 @@ GBFS {
 
 exports[`initialization with auth should correctly initialize with \`bearer_token\` 1`] = `
 GBFS {
-  "auth": Object {
-    "bearerToken": Object {
+  "auth": {
+    "bearerToken": {
       "token": "mytoken",
     },
     "type": "bearer_token",
   },
-  "gotOptions": Object {
-    "headers": Object {
+  "gotOptions": {
+    "headers": {
       "Authorization": "Bearer mytoken",
     },
   },
-  "options": Object {
-    "docked": false,
-    "freefloating": false,
-    "version": null,
-  },
-  "url": "http://localhost:8888/gbfs.json",
-}
-`;
-
-exports[`initialization with auth should correctly initialize with one \`headers\` 1`] = `
-GBFS {
-  "auth": Object {
-    "headers": Array [
-      Object {
-        "key": "mykey",
-        "value": "myvalue",
-      },
-    ],
-    "type": "headers",
-  },
-  "gotOptions": Object {
-    "headers": Object {
-      "mykey": "myvalue",
-    },
-  },
-  "options": Object {
+  "options": {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -100,31 +83,58 @@ GBFS {
 
 exports[`initialization with auth should correctly initialize with multiple \`headers\` 1`] = `
 GBFS {
-  "auth": Object {
-    "headers": Array [
-      Object {
+  "auth": {
+    "headers": [
+      {
         "key": "mykey",
         "value": "myvalue",
       },
-      Object {
+      {
         "key": "mysecondkey",
         "value": "mysecondvalue",
       },
-      Object {
+      {
         "key": "mythirdkey",
         "value": "mythirdvalue",
       },
     ],
     "type": "headers",
   },
-  "gotOptions": Object {
-    "headers": Object {
+  "gotOptions": {
+    "headers": {
       "mykey": "myvalue",
       "mysecondkey": "mysecondvalue",
       "mythirdkey": "mythirdvalue",
+      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
     },
   },
-  "options": Object {
+  "options": {
+    "docked": false,
+    "freefloating": false,
+    "version": null,
+  },
+  "url": "http://localhost:8888/gbfs.json",
+}
+`;
+
+exports[`initialization with auth should correctly initialize with one \`headers\` 1`] = `
+GBFS {
+  "auth": {
+    "headers": [
+      {
+        "key": "mykey",
+        "value": "myvalue",
+      },
+    ],
+    "type": "headers",
+  },
+  "gotOptions": {
+    "headers": {
+      "mykey": "myvalue",
+      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+    },
+  },
+  "options": {
     "docked": false,
     "freefloating": false,
     "version": null,

--- a/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
+++ b/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`initialization should correctly initialize validator per default 1`] = `
 GBFS {
-  "auth": {},
-  "gotOptions": {
-    "headers": {
+  "auth": Object {},
+  "gotOptions": Object {
+    "headers": Object {
       "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
     },
   },
-  "options": {
+  "options": Object {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -19,13 +19,13 @@ GBFS {
 
 exports[`initialization should correctly initialize validator with options 1`] = `
 GBFS {
-  "auth": {},
-  "gotOptions": {
-    "headers": {
+  "auth": Object {},
+  "gotOptions": Object {
+    "headers": Object {
       "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
     },
   },
-  "options": {
+  "options": Object {
     "docked": true,
     "freefloating": true,
     "version": "v2.1",
@@ -38,19 +38,19 @@ exports[`initialization should throw an error without url 1`] = `"Missing URL"`;
 
 exports[`initialization with auth should correctly initialize with \`basic_auth\` 1`] = `
 GBFS {
-  "auth": {
-    "basicAuth": {
+  "auth": Object {
+    "basicAuth": Object {
       "password": "mypassword",
       "user": "myuser",
     },
     "type": "basic_auth",
   },
-  "gotOptions": {
-    "headers": {
+  "gotOptions": Object {
+    "headers": Object {
       "Authorization": "basic bXl1c2VyOm15cGFzc3dvcmQ=",
     },
   },
-  "options": {
+  "options": Object {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -61,18 +61,18 @@ GBFS {
 
 exports[`initialization with auth should correctly initialize with \`bearer_token\` 1`] = `
 GBFS {
-  "auth": {
-    "bearerToken": {
+  "auth": Object {
+    "bearerToken": Object {
       "token": "mytoken",
     },
     "type": "bearer_token",
   },
-  "gotOptions": {
-    "headers": {
+  "gotOptions": Object {
+    "headers": Object {
       "Authorization": "Bearer mytoken",
     },
   },
-  "options": {
+  "options": Object {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -83,32 +83,32 @@ GBFS {
 
 exports[`initialization with auth should correctly initialize with multiple \`headers\` 1`] = `
 GBFS {
-  "auth": {
-    "headers": [
-      {
+  "auth": Object {
+    "headers": Array [
+      Object {
         "key": "mykey",
         "value": "myvalue",
       },
-      {
+      Object {
         "key": "mysecondkey",
         "value": "mysecondvalue",
       },
-      {
+      Object {
         "key": "mythirdkey",
         "value": "mythirdvalue",
       },
     ],
     "type": "headers",
   },
-  "gotOptions": {
-    "headers": {
+  "gotOptions": Object {
+    "headers": Object {
       "mykey": "myvalue",
       "mysecondkey": "mysecondvalue",
       "mythirdkey": "mythirdvalue",
       "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
     },
   },
-  "options": {
+  "options": Object {
     "docked": false,
     "freefloating": false,
     "version": null,
@@ -119,22 +119,22 @@ GBFS {
 
 exports[`initialization with auth should correctly initialize with one \`headers\` 1`] = `
 GBFS {
-  "auth": {
-    "headers": [
-      {
+  "auth": Object {
+    "headers": Array [
+      Object {
         "key": "mykey",
         "value": "myvalue",
       },
     ],
     "type": "headers",
   },
-  "gotOptions": {
-    "headers": {
+  "gotOptions": Object {
+    "headers": Object {
       "mykey": "myvalue",
       "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
     },
   },
-  "options": {
+  "options": Object {
     "docked": false,
     "freefloating": false,
     "version": null,

--- a/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
+++ b/gbfs-validator/__test__/__snapshots__/gbfs.test.js.snap
@@ -5,7 +5,7 @@ GBFS {
   "auth": Object {},
   "gotOptions": Object {
     "headers": Object {
-      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+      "user-agent": "MobilityData GBFS-Validator/1.1.1 (Node 16.0.1)",
     },
   },
   "options": Object {
@@ -22,7 +22,7 @@ GBFS {
   "auth": Object {},
   "gotOptions": Object {
     "headers": Object {
-      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+      "user-agent": "MobilityData GBFS-Validator/1.1.1 (Node 16.0.1)",
     },
   },
   "options": Object {
@@ -105,7 +105,7 @@ GBFS {
       "mykey": "myvalue",
       "mysecondkey": "mysecondvalue",
       "mythirdkey": "mythirdvalue",
-      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+      "user-agent": "MobilityData GBFS-Validator/1.1.1 (Node 16.0.1)",
     },
   },
   "options": Object {
@@ -131,7 +131,7 @@ GBFS {
   "gotOptions": Object {
     "headers": Object {
       "mykey": "myvalue",
-      "user-agent": "MobilityData GBFS-Validator/1.0.0 (Node 18.20.0)",
+      "user-agent": "MobilityData GBFS-Validator/1.1.1 (Node 16.0.1)",
     },
   },
   "options": Object {

--- a/gbfs-validator/__test__/gbfs.test.js
+++ b/gbfs-validator/__test__/gbfs.test.js
@@ -1,4 +1,5 @@
 const GBFS = require('../gbfs')
+const pjson = require('../package.json')
 
 const serverOpts = {
   port: 0,
@@ -6,6 +7,14 @@ const serverOpts = {
 }
 
 describe('initialization', () => {
+
+  beforeAll(() => {
+    // mocks process and pacakge.json for consistent tests
+    const originalProcess = process
+    global.process = {...originalProcess, versions: {node: '16.0.1'}}
+    pjson.version = '1.1.1'
+  })
+
   test('should correctly initialize validator per default', () => {
     expect(new GBFS('http://localhost:8888/gbfs.json')).toMatchSnapshot()
   })

--- a/gbfs-validator/gbfs.js
+++ b/gbfs-validator/gbfs.js
@@ -1,5 +1,6 @@
 const got = require('got')
 const validate = require('./validate')
+var packageJson = require('./package.json');
 const validatorVersion = process.env.COMMIT_REF
   ? process.env.COMMIT_REF.substring(0, 7)
   : require('./package.json').version
@@ -281,6 +282,8 @@ class GBFS {
       throw new Error('Missing URL')
     }
 
+    const userAgent = `MobilityData GBFS-Validator/${packageJson?.version} (Node ${process?.versions['node']})`
+
     this.url = url
     this.options = {
       docked,
@@ -289,7 +292,11 @@ class GBFS {
     }
     this.auth = auth
 
-    this.gotOptions = {}
+    this.gotOptions = {
+      headers: {
+        'user-agent': userAgent
+      }
+    }
 
     if (this.auth && this.auth.type) {
       if (this.auth.type === 'basic_auth' && this.auth.basicAuth) {
@@ -308,7 +315,9 @@ class GBFS {
       }
 
       if (this.auth.type === 'headers') {
-        this.gotOptions.headers = {}
+        this.gotOptions.headers = {
+          'user-agent': userAgent
+        }
         for (var header of this.auth.headers) {
           if (header && header.value) {
             this.gotOptions.headers[header.key] = header.value


### PR DESCRIPTION
#90 
Certain feeds such as: https://mds.linkyour.city/gbfs/es_granada/gbfs.json block the default user-agent used by GOT. This PR changes the default user-agent to the format: `MobilityData GBFS-Validator/{VALIDATOR_VERSION} (NOde {NODE_VERSION})`

With the new user-agent header, this feed works
![image](https://github.com/MobilityData/gbfs-validator/assets/18631060/181756fe-383d-499d-b3f7-33f003e85b8f)
