### PR TITLE
bumped package version and dev dependencies

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,6 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
-    "gbfs-validator": "file:../gbfs-validator"
+    "gbfs-validator": "~1.0.0"
+  },
+  "devDependencies": {
+    "gbfs-validator": "file:../gbfs-validator" 
   }
 }

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,17 +6051,6 @@ gauge@^3.0.0:
     strip-ansi "^6.0.1"
     wide-align "^1.1.2"
 
-"gbfs-validator@file:gbfs-validator":
-  version "1.0.7"
-  dependencies:
-    ajv "^8.9.0"
-    ajv-errors "^3.0.0"
-    ajv-formats "^2.1.1"
-    commander "^11.0.0"
-    fast-json-patch "^3.1.0"
-    got "^11.8.2"
-    json-merge-patch "^1.0.2"
-
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
1. Bumped gbfs-validator to version 1.08 to include user agent fix in package
2. Added dependency management in 'functions' to use latest published in prod but local file for development