### PR TITLE
gbfs validator script fix

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -17,4 +17,4 @@ jobs:
         run: npm install -g node-gyp@latest
    
       - name: Run tests
-        run: yarn install && yarn run prepare && yarn workspaces run test
+        run: yarn install && yarn workspaces run test

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -17,4 +17,4 @@ jobs:
         run: npm install -g node-gyp@latest
    
       - name: Run tests
-        run: yarn install && yarn workspaces run test
+        run: yarn install && yarn run prepare && yarn workspaces run test

--- a/gbfs-validator/README.md
+++ b/gbfs-validator/README.md
@@ -13,6 +13,16 @@ first install our [Node.js npm package](https://www.npmjs.com/package/gbfs-valid
 npm install gbfs-validator
 ```
 
+## Supported GBFS Versions
+- 3.1-RC
+- 3.0
+- 2.3
+- 2.2
+- 2.1
+- 2.0
+- 1.1
+- 1.0
+
 ## Example Code
 ```javascript 
 const GBFS = require('gbfs-validator');

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "test": "jest",
-    "postinstall": "git submodule update --init --recursive"
+    "prepare": "git submodule update --init --recursive"
   },
   "dependencies": {
     "ajv": "^8.9.0",

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "yarn run dev",
     "lint": "eslint --ext .js,.vue website/src",
     "build": "yarn workspace website build",
-    "build:website": "cd website && yarn run build"
+    "build:website": "cd website && yarn run build",
+    "postinstall": "git submodule update --init --recursive"
   },
   "devDependencies": {
     "eslint": "^8.41.0",


### PR DESCRIPTION
There was an issue when installing the npm package `npm i gbfs-validator --save` after the submodule addition. I discovered from the package.json `postinstall` script will trigger when users install the package using `npm i gbfs-validator --save`. This caused an error where it would try to update the submodules when trying to download the package.

Solution
The `prepare` lifecycle script will trigger a submodule update on a local `npm install` but NOT when a user downloads the package `npm i gbfs-validator --save`. It will also trigger just before `npm publish`. This is the functionality we wanted from the beginning 

Note: I deployed version 1.0.11 locally to make sure this fix works, and it does!