### PR TITLE
update npm token for publish

### DIFF
--- a/.github/workflows/publish_validator.yml
+++ b/.github/workflows/publish_validator.yml
@@ -65,9 +65,17 @@ jobs:
     
             - name: Install dependencies
               run: yarn
+            
+            - name: Load secrets from 1Password
+              uses: 1password/load-secrets-action@v1.3.1
+              with:
+                export-env: true # Export loaded secrets as environment variables
+              env:
+                OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+                NODE_AUTH_TOKEN: "op://TECHNOLOGIES/vwhmodynvelkwrqbpel45ncve4/credential"
     
             - name: Publish to npm
               run: npm publish
               env:
-                NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+                NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
                 

--- a/.github/workflows/publish_validator.yml
+++ b/.github/workflows/publish_validator.yml
@@ -67,7 +67,7 @@ jobs:
               run: yarn
             
             - name: Load secrets from 1Password
-              uses: 1password/load-secrets-action@v1.3.1
+              uses: 1password/load-secrets-action@v2.0.0
               with:
                 export-env: true # Export loaded secrets as environment variables
               env:


### PR DESCRIPTION
As the current npm token to publish the typescript package is set to expire, the new one is set using onepassword