### PR TITLE
feat: update generic error message

### DIFF
--- a/website/src/components/Result.vue
+++ b/website/src/components/Result.vue
@@ -25,21 +25,19 @@ const errorsCountFormated = computed(() => {
       <div v-if="result.summary">
         <h3 class="mt-4 mb-4">Result</h3>
 
-        <b-alert
-          v-if="result.summary.versionUnimplemented"
-          variant="danger"
-          show
-        >
-          Sorry, this version is not yet implemented or not detectable !
+        <b-alert v-if="result.summary.versionUnimplemented" variant="danger" show>
+          Sorry, the validator failed to parse this file. Please check that the URL is available and points to a
+          gbfs.json file. If you have any questions, please write to <a href='mailto:sharedmobility@mobilitydata.org'
+            target='_blank' rel='noreferrer'>
+            sharedmobility@mobilitydata.org
+          </a>. Thank you
         </b-alert>
         <div v-else>
           <b-alert variant="info" show>
             Detected version <b>{{ result.summary.version.detected }} </b> and
             validate with
-            <a
-              :href="`https://github.com/MobilityData/gbfs/blob/v${result.summary.version.validated}/gbfs.md`"
-              ><b>{{ result.summary.version.validated }}</b></a
-            >
+            <a :href="`https://github.com/MobilityData/gbfs/blob/v${result.summary.version.validated}/gbfs.md`"><b>{{
+              result.summary.version.validated }}</b></a>
           </b-alert>
 
           <div>

--- a/website/src/components/Result.vue
+++ b/website/src/components/Result.vue
@@ -27,8 +27,9 @@ const errorsCountFormated = computed(() => {
 
         <b-alert v-if="result.summary.versionUnimplemented" variant="danger" show>
           Sorry, the validator failed to parse this file. Please check that the URL is available and points to a
-          gbfs.json file. If you have any questions, please write to <a href='mailto:sharedmobility@mobilitydata.org'
-            target='_blank' rel='noreferrer'>
+          <a href="https://github.com/MobilityData/gbfs/blob/master/gbfs.md#gbfsjson" target='_blank'
+            rel='noreferrer'>gbfs.json</a> file. If you have any questions, please write to <a
+            href='mailto:sharedmobility@mobilitydata.org' target='_blank' rel='noreferrer'>
             sharedmobility@mobilitydata.org
           </a>. Thank you
         </b-alert>

--- a/website/src/pages/Visualization.vue
+++ b/website/src/pages/Visualization.vue
@@ -479,8 +479,9 @@ provide('map', map)
     <b-row class="mt-3" v-if="summary.versionUnimplemented"><b-col>
         <b-alert variant="danger" show class="mb-0">
           Sorry, the validator failed to parse this file. Please check that the URL is available and points to a
-          gbfs.json file. If you have any questions, please write to <a href='mailto:sharedmobility@mobilitydata.org'
-            target='_blank' rel='noreferrer'>
+          <a href="https://github.com/MobilityData/gbfs/blob/master/gbfs.md#gbfsjson" target='_blank'
+            rel='noreferrer'>gbfs.json</a> file. If you have any questions, please write to <a
+            href='mailto:sharedmobility@mobilitydata.org' target='_blank' rel='noreferrer'>
             sharedmobility@mobilitydata.org
           </a>. Thank you
         </b-alert>

--- a/website/src/pages/Visualization.vue
+++ b/website/src/pages/Visualization.vue
@@ -469,29 +469,22 @@ provide('map', map)
   <div>
     <b-row>
       <b-col>
-        <b-form-input
-          type="url"
-          v-model="url"
-          placeholder="https://exemple.com/gbfs.json"
-        ></b-form-input>
+        <b-form-input type="url" v-model="url" placeholder="https://exemple.com/gbfs.json"></b-form-input>
       </b-col>
       <b-col class="flex-grow-0">
-        <b-button
-          @click="visualize"
-          variant="success"
-          style="white-space: nowrap"
-          :disabled="isLoading"
-          >Visualize !</b-button
-        >
+        <b-button @click="visualize" variant="success" style="white-space: nowrap" :disabled="isLoading">Visualize
+          !</b-button>
       </b-col>
     </b-row>
-    <b-row class="mt-3" v-if="summary.versionUnimplemented"
-      ><b-col>
+    <b-row class="mt-3" v-if="summary.versionUnimplemented"><b-col>
         <b-alert variant="danger" show class="mb-0">
-          Sorry, this version is not yet implemented or not detectable !
+          Sorry, the validator failed to parse this file. Please check that the URL is available and points to a
+          gbfs.json file. If you have any questions, please write to <a href='mailto:sharedmobility@mobilitydata.org'
+            target='_blank' rel='noreferrer'>
+            sharedmobility@mobilitydata.org
+          </a>. Thank you
         </b-alert>
-      </b-col></b-row
-    >
+      </b-col></b-row>
     <b-row class="mt-3">
       <b-col cols="6">
         <b-alert variant="primary" show>
@@ -499,7 +492,7 @@ provide('map', map)
             {{ stations ? stations.length : '-' }}
             <small v-if="hasStationsDetails" class="text-muted">{{
               vehiclesInStations
-            }}</small>
+              }}</small>
           </h4>
           <span>Stations</span>
         </b-alert>
@@ -508,11 +501,7 @@ provide('map', map)
         <b-alert variant="primary" show>
           <h4 class="alert-heading">
             {{ vehicles ? vehicles.length : '-' }}
-            <small
-              v-if="vehicleTypes && vehicleTypes.length > 1"
-              class="text-muted"
-              >{{ vehiclesCountByType }}</small
-            >
+            <small v-if="vehicleTypes && vehicleTypes.length > 1" class="text-muted">{{ vehiclesCountByType }}</small>
           </h4>
           <span>Dockless vehicles</span>
         </b-alert>
@@ -526,25 +515,15 @@ provide('map', map)
           <div class="map-overlay top left">
             <div class="map-overlay-inner">
               <ul class="list-unstyled mb-0">
-                <b-form-checkbox-group
-                  id="checkbox-group-2"
-                  v-model="selected"
-                  name="flavour-2"
-                >
+                <b-form-checkbox-group id="checkbox-group-2" v-model="selected" name="flavour-2">
                   <li>
-                    <b-form-checkbox name="selected-stations" value="stations"
-                      >&nbsp;Stations</b-form-checkbox
-                    >
+                    <b-form-checkbox name="selected-stations" value="stations">&nbsp;Stations</b-form-checkbox>
                   </li>
                   <li>
-                    <b-form-checkbox name="selected-stations" value="vehicles"
-                      >&nbsp;Dockless</b-form-checkbox
-                    >
+                    <b-form-checkbox name="selected-stations" value="vehicles">&nbsp;Dockless</b-form-checkbox>
                   </li>
                   <li>
-                    <b-form-checkbox name="selected-stations" value="geofencing"
-                      >&nbsp;Geofencing</b-form-checkbox
-                    >
+                    <b-form-checkbox name="selected-stations" value="geofencing">&nbsp;Geofencing</b-form-checkbox>
                   </li>
                 </b-form-checkbox-group>
               </ul>
@@ -555,21 +534,12 @@ provide('map', map)
             <div class="map-overlay-inner" v-if="vehicles">
               <h5>Dockless vehicles</h5>
               <ul class="list-unstyled mb-0">
-                <li
-                  v-for="vtff in vehicleTypesFormFactor"
-                  :key="vtff"
-                  class="d-flex align-items-center"
-                >
-                  <span
-                    class="vehicle-type d-inline-block"
-                    :class="`vehicle-type-${vtff.toLowerCase()}`"
-                  ></span>
+                <li v-for="vtff in vehicleTypesFormFactor" :key="vtff" class="d-flex align-items-center">
+                  <span class="vehicle-type d-inline-block" :class="`vehicle-type-${vtff.toLowerCase()}`"></span>
                   {{ vtff }}
                 </li>
                 <li v-if="!vehicleTypesFormFactor">
-                  <span
-                    class="vehicle-type d-inline-block vehicle-type-unknown"
-                  ></span>
+                  <span class="vehicle-type d-inline-block vehicle-type-unknown"></span>
                   unknown
                 </li>
               </ul>
@@ -628,6 +598,7 @@ provide('map', map)
   &.left {
     left: 0;
   }
+
   &.top {
     top: 0;
   }


### PR DESCRIPTION
Changed error message from 
Old: "Sorry, this version is not yet implemented or not detectable !"
New: "Sorry, the validator failed to parse this file. Please check that the URL is available and points to a [gbfs.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#gbfsjson) file. If you have any questions, please write to [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org). Thank you

Also ran Vue linter - no functionality changed

How to test
On the validator input a non valid gbfs link ex: `https://www.mibicitubici.gob.ar/` you should see the error message


