### PR TITLE
fix: corrected NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish_validator.yml
+++ b/.github/workflows/publish_validator.yml
@@ -14,7 +14,7 @@ jobs:
         defaults:
           run:
             working-directory: ./gbfs-validator
-    
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
@@ -22,11 +22,11 @@ jobs:
             - name: Get current published version
               id: get_current_published_version
               run: echo "VERSION=$(npm info gbfs-validator version)" >> $GITHUB_OUTPUT
-      
+
             - name: Get current local version
               id: get_current_local_version
               run: echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-              
+
             - name: Check if version changed
               id: version-change-check
               env:
@@ -62,20 +62,20 @@ jobs:
               with:
                 node-version: '18'
                 registry-url: 'https://registry.npmjs.org'
-    
+
             - name: Install dependencies
               run: yarn
-            
+
             - name: Load secrets from 1Password
               uses: 1password/load-secrets-action@v2.0.0
               with:
                 export-env: true # Export loaded secrets as environment variables
               env:
                 OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-                NODE_AUTH_TOKEN: "op://TECHNOLOGIES/vwhmodynvelkwrqbpel45ncve4/credential"
-    
+                NODE_AUTH_TOKEN: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ppzc4jxrwkf3omdmcs7z2wiwum/credential"
+
             - name: Publish to npm
               run: npm publish
               env:
                 NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
-                
+


### PR DESCRIPTION
NODE_AUTH_TOKEN was using secret from TECHNOLOGIES vault, which is not shared externally. It's odd that it worked fine even though it couldn’t. 