### PR TITLE
fixed v3 visualizations vehicles at stations

### DIFF
--- a/website/src/pages/Visualization.vue
+++ b/website/src/pages/Visualization.vue
@@ -38,7 +38,6 @@ let stationsOverlay
 let geofencingOverlay
 
 const MAPBOX_KEY = import.meta.env.VITE_MAPBOX_API_KEY
-
 // https://github.com/rowanwins/maplibregl-mapbox-request-transformer
 const transformRequest = (url = '', resourceType = '') => {
   if (isMapboxURL(url)) {
@@ -191,7 +190,7 @@ const hasStationsDetails = computed(() => {
 const vehiclesInStations = computed(() => {
   if (get(stations)) {
     return `${get(stations).reduce((acc, s) => {
-      acc += getStationStatus(s.station_id)?.num_bikes_available || 0
+      acc += getStationStatus(s.station_id)?.num_bikes_available || getStationStatus(s.station_id)?.num_vehicles_available || 0 // num_bikes_available changed name in V3
 
       return acc
     }, 0)} vehicles`
@@ -421,9 +420,13 @@ function populateData() {
       pointRadiusMinPixels: 3,
       stroked: false,
       getFillColor: (info) => {
-        if (info.properties._info.num_bikes_available > 5) {
+        const vehiclesAvailable =
+          info.properties._info.num_bikes_available ||
+          info.properties._info.num_vehicles_available || // changed name in V3
+          0
+        if (vehiclesAvailable > 5) {
           return [6, 156, 86]
-        } else if (info.properties._info.num_bikes_available > 0) {
+        } else if (vehiclesAvailable > 0) {
           return [255, 152, 14]
         } else {
           return [211, 33, 44]


### PR DESCRIPTION
The gbfs validator visualizer was not correctly displaying the number of vehicles at each respective station for v3 feeds

closes: #203 

Reason
The gbfs validator visualizations used the property `num_bikes_available`, this property's name was changed in v3 to `num_vehicles_available`. This change was not reflected in the visualizer

(Ignore missing basemaps)

Before
<img width="1205" height="1038" alt="Screenshot 2025-11-10 at 12 04 43" src="https://github.com/user-attachments/assets/f78c5c79-5452-489e-9f59-c47adaf34f23" />

After
<img width="1133" height="986" alt="Screenshot 2025-11-10 at 12 11 00" src="https://github.com/user-attachments/assets/8a0c7599-2b0f-4e68-a69e-ebbf31a18933" />
