### PR TITLE
fix zoom on single station

### DIFF
--- a/website/src/pages/Visualization.vue
+++ b/website/src/pages/Visualization.vue
@@ -262,6 +262,15 @@ const getStationStatus = function (stationId) {
   }
 }
 
+function fitBoundsForGeojson(geojson) {
+  if (geojson.features.length === 1 && geojson.features[0].geometry.type === 'Point') {
+    const [lng, lat] = geojson.features[0].geometry.coordinates
+    mapInstance.flyTo({ center: [lng, lat], zoom: 11 })
+  } else {
+    mapInstance.fitBounds(bboxPolygon(geojson))
+  }
+}
+
 function populateData() {
   if (get(selected).includes('geofencing') && get(geofencingZone)) {
     const geojson = {
@@ -309,7 +318,7 @@ function populateData() {
       layers: [geofencingLayer]
     })
 
-    mapInstance.fitBounds(bboxPolygon(geojson))
+    fitBoundsForGeojson(geojson)
     mapInstance.addControl(geofencingOverlay)
   }
 
@@ -384,7 +393,7 @@ function populateData() {
       layers: [vehiclesLayer]
     })
 
-    mapInstance.fitBounds(bboxPolygon(geojson))
+    fitBoundsForGeojson(geojson)
     mapInstance.addControl(vehiclesOverlay)
   }
 
@@ -449,7 +458,7 @@ function populateData() {
       layers: [stationLayer]
     })
 
-    mapInstance.fitBounds(bboxPolygon(geojson))
+    fitBoundsForGeojson(geojson)
     mapInstance.addControl(stationsOverlay)
   }
 }


### PR DESCRIPTION
The GBFS validator visualizer kept zooming on a station when the passed GBFS feed only contained 1 station.

closes: #133 

Reason:
This was caused by the fact that the `mapInstance.fitBounds(bboxPolygon(geojson))` didn't behave as expected when called with just one data point, as the function will fit the view to the given area. If the passed parameter has an area of 0 (it's a single point) it'll continue to zoom indefinitely.

I created an utility function `fitBoundsForGeojson` to address this issue and fly to the specific station in case it's one. It will also be used for the vehicles and geofencing layer as well, as they'd also be subject to the same issue.

Feed used for testing: https://data.lime.bike/api/partners/v2/gbfs/opfikon/gbfs.json

Before:

https://github.com/user-attachments/assets/f329b431-0a36-46b3-b8f5-c500c594c0be

After:

https://github.com/user-attachments/assets/21e8f140-ff4f-4ff3-ba55-109a3a09557a

