### PR TITLE
Feat: trusted publisher publishing

### DIFF
--- a/.github/workflows/publish_validator.yml
+++ b/.github/workflows/publish_validator.yml
@@ -3,7 +3,13 @@ name: GBFS Validator Package - Publish
 on:
     push:
       branches:
-        - master
+        - feat/trusted-publisher-publishing
+
+# Npm authentication via OpenID Connect (OIDC)
+# https://docs.npmjs.com/trusted-publishers
+permissions:
+    id-token: write  # Required for OIDC
+    contents: read
 
 jobs:
     check-versions:
@@ -58,24 +64,18 @@ jobs:
                 fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
-                node-version: '18'
+                node-version: '20'
                 registry-url: 'https://registry.npmjs.org'
 
             - name: Install dependencies
               run: yarn
 
-            - name: Load secrets from 1Password
-              uses: 1password/load-secrets-action@v2.0.0
-              with:
-                export-env: true # Export loaded secrets as environment variables
-              env:
-                OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-                NODE_AUTH_TOKEN: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ppzc4jxrwkf3omdmcs7z2wiwum/credential"
-
+            # Ensure npm 11.5.1 or later is installed for OIDC support
+            - name: Update npm
+              run: npm install -g npm@11.6.2
+      
             - name: Publish to npm
               run: npm publish
-              env:
-                NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
 

--- a/.github/workflows/publish_validator.yml
+++ b/.github/workflows/publish_validator.yml
@@ -3,7 +3,7 @@ name: GBFS Validator Package - Publish
 on:
     push:
       branches:
-        - feat/trusted-publisher-publishing
+        - master
 
 # Npm authentication via OpenID Connect (OIDC)
 # https://docs.npmjs.com/trusted-publishers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![All Contributors](https://img.shields.io/github/all-contributors/MobilityData/gbfs-validator?color=blue&style=flat)](#contributors)
 
-A [General Bikeshare Feed Specification](https://github.com/MobilityData/gbfs) dataset validator.
+A [General Bikeshare Feed Specification](https://github.com/MobilityData/gbfs) dataset validator
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![All Contributors](https://img.shields.io/github/all-contributors/MobilityData/gbfs-validator?color=blue&style=flat)](#contributors)
 
-A [General Bikeshare Feed Specification](https://github.com/MobilityData/gbfs) dataset validator
+A [General Bikeshare Feed Specification](https://github.com/MobilityData/gbfs) dataset validator.
 
 ## Introduction
 

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Sets up Trusted Publishing for `npm publish` the gbfs-validator package. This will remove the need to manage npm tokens

Test publish is successful: https://www.npmjs.com/package/gbfs-validator

<img width="883" height="290" alt="Screenshot 2026-01-27 at 14 36 44" src="https://github.com/user-attachments/assets/79707e43-d423-49a2-af35-6a2e9f2a580c" />

