### PR TITLE
update the gbfs-json-schema

### DIFF
--- a/gbfs-validator/__test__/gbfs.test.js
+++ b/gbfs-validator/__test__/gbfs.test.js
@@ -554,7 +554,7 @@ describe('required default_reserve_time on reservation price existing v3.1-RC2',
         summary: expect.objectContaining({
           version: { detected: '3.1-RC2', validated: '3.1-RC2' },
           hasErrors: true,
-          errorsCount: 3
+          errorsCount: 4
         }),
         files: expect.arrayContaining([
           expect.objectContaining(

--- a/gbfs-validator/package.json
+++ b/gbfs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-validator",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "MobilityData",
   "main": "index.js",
   "license": "MIT",
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "test": "jest",
-    "prepare": "git submodule update --init --recursive"
+    "prepare": "git submodule update --init --recursive",
+    "update-schemas": "git submodule update --remote"
   },
   "dependencies": {
     "ajv": "^8.9.0",


### PR DESCRIPTION
This PR updates the github submodule PR to the latest gbfs-json-schema allowing the validator to run against the latest changes

closes #212 